### PR TITLE
Modify script to enable adsimdetector IOC build

### DIFF
--- a/ansible/roles/epics-modules/tasks/adsimdetector_prep.yml
+++ b/ansible/roles/epics-modules/tasks/adsimdetector_prep.yml
@@ -6,11 +6,34 @@
     line: '-include $(TOP)/../RELEASE.local'
   become: true
 
+- name: "{{ epics_modules[item].name }} | Fix configure/CONFIG_SITE to include BUILD_IOCS"
+  ansible.builtin.lineinfile:
+    path: "{{ epics_install_path }}/{{ item }}-{{ epics_modules[item].version }}/configure/CONFIG_SITE"
+    line: 'BUILD_IOCS = YES'
+    insertafter: EOF
+    state: present
+  become: true
+
 - name: "{{ epics_modules[item].name }} | Fix example IOC configure/RELEASE to include RELEASE.local"
   ansible.builtin.lineinfile:
     path: "{{ epics_install_path }}/{{ item }}-{{ epics_modules[item].version }}/iocs/simDetectorIOC/configure/RELEASE"
     search_string: '-include $(TOP)/RELEASE.local'
-    line: '-include $(TOP)/../RELEASE.local'
+    line: '-include $(TOP)/../../../RELEASE.local'
+  become: true
+
+- name: "{{ epics_modules[item].name }} | Fix example IOC configure/RELEASE to include RELEASE.local"
+  ansible.builtin.lineinfile:
+    path: "{{ epics_install_path }}/{{ item }}-{{ epics_modules[item].version }}/iocs/simDetectorNoIOC/configure/RELEASE"
+    search_string: '-include $(TOP)/RELEASE.local'
+    line: '-include $(TOP)/../../../RELEASE.local'
+  become: true
+
+- name: "{{ epics_modules[item].name }} | Fix example IOC add a configuration to configure/CONFIG_SITE"
+  ansible.builtin.lineinfile:
+    path: "{{ epics_install_path }}/{{ item }}-{{ epics_modules[item].version }}/iocs/simDetectorNoIOC/configure/CONFIG_SITE"
+    line: 'XML2_INCLUDE += /usr/include/libxml2'
+    insertafter: EOF
+    state: present
   become: true
 
 - name: "{{ epics_modules[item].name }} | Make example IOC include ADCORE/configure/CONFIG_SITE"

--- a/ansible/roles/epics-modules/tasks/build_module.yml
+++ b/ansible/roles/epics-modules/tasks/build_module.yml
@@ -69,7 +69,9 @@
   when: epics_modules[item].pre_hook is defined
 
 - name: "{{ epics_modules[item].name }} | Build from sources (this may take a while)"
-  command: make -C "{{ epics_install_path }}/{{ item }}-{{ epics_modules[item].version }}" all clean
+  command: >
+    make -C "{{ epics_install_path }}/{{ item }}-{{ epics_modules[item].version }}"
+    {{ 'all clean' if item != 'adsimdetector' else 'all' }}
   register: build_result
   become: true
   when: epics_module_flag.stat.exists == false

--- a/ansible/roles/epics-tools/tasks/install_java.yml
+++ b/ansible/roles/epics-tools/tasks/install_java.yml
@@ -16,16 +16,20 @@
   register: java_installation
   changed_when: false
 
-- name: install open jdk 17
+- name: Set architecture specific variable
+  set_fact:
+    custom_architecture: "{{ 'x64' if ansible_facts['architecture'] == 'x86_64' else ansible_facts['architecture'] }}"
+
+- name: Install OpenJDK 17
   become: true
   ansible.builtin.unarchive:
-    src: "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.10%2B7/OpenJDK17U-jdk_{{ ansible_facts['architecture'] }}_linux_hotspot_17.0.10_7.tar.gz"
+    src: "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.10%2B7/OpenJDK17U-jdk_{{ custom_architecture }}_linux_hotspot_17.0.10_7.tar.gz"
     dest: "{{ java_home }}"
     remote_src: yes
     owner:  "{{ epics_services_account }}"
     group:  "{{ epics_services_account }}"
     extra_opts:
-    - --strip-components=1
+      - --strip-components=1
   when: java_installation.stat.exists == false
 
 - name: Add CA certificate to java trust store


### PR DESCRIPTION
## Overview

This pull request modifies the scripts to ensure that the `adsimdetector` IOC builds correctly. The main changes are as follows:

## Changes

1. **adsimdetector_prep.yml**:
   - Included additional configurations for example IOC.
   - Set `BUILD_IOCS` to `YES`.
   - Added a line to include the `XML2_INCLUDE` path in simDetectorNoIOC's CONFIG_SITE.

2. **build_module.yml**:
   - Updated to conditionally exclude the `clean` step for the `adsimdetector` module during the build process.

## Details

### adsimdetector_prep.yml
- Modified to include additional configurations necessary for the example IOC setup.
- Added configuration to set `BUILD_IOCS` to `YES` to ensure the IOC builds correctly.
- Added `XML2_INCLUDE += /usr/include/libxml2` to ensure the correct path for XML2 headers is included during the build.

### build_module.yml
- Updated the build command to conditionally exclude the `clean` step for the `adsimdetector` module. This allows for faster builds when changes do not require a full clean build.