### PR TITLE
Added ternary logic to fix Java jdk binary download link

### DIFF
--- a/ansible/roles/epics-tools/tasks/install_java.yml
+++ b/ansible/roles/epics-tools/tasks/install_java.yml
@@ -19,7 +19,7 @@
 - name: install open jdk 17
   become: true
   ansible.builtin.unarchive:
-    src: "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.10%2B7/OpenJDK17U-jdk_{{ ansible_facts['architecture'] }}_linux_hotspot_17.0.10_7.tar.gz"
+    src: "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.10%2B7/OpenJDK17U-jdk_{{ (ansible_facts['architecture'] == 'x86_64') | ternary('x64', ansible_facts['architecture']) }}_linux_hotspot_17.0.10_7.tar.gz"
     dest: "{{ java_home }}"
     remote_src: yes
     owner:  "{{ epics_services_account }}"


### PR DESCRIPTION
Overview
---
This is a small bug fix for the Java jdk download link on x86 64Bit architecture.

Issue
---

I was testing the installation process on a Rocky 9.4 VM. Everything works fine until it reaches the Java jdk download. The code reports that it couldn't find the tar file. 

This happens because the link to the Java binaries is incorrect:

```
 src: "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.10%2B7/OpenJDK17U-jdk_{{ ansible_facts['architecture'] }}_linux_hotspot_17.0.10_7.tar.gz"
```
This would work, but the java binaries use a different string to denote 64-bit x86 CPU architecture than Ansible. So the code will request the file with the "x86_64" tag when the corresponding file is tagged with "x64". 

Workaround
---

My solution was to add a ternary condition to replace the 'x86_64' string with 'x64', otherwise it keeps the string value from `ansible_facts['architecture']`.

This fixes the issue on this type of CPU architecture, but it might not work on all others (depending on whether or not the strings match). So far I haven't been able to find a list of possible values returned by `ansible_facts['architecture']`, so I can't add a more comprehensive fix. 

Does this seem like a reasonable solution? I'm happy to help improve it.
