### PR TITLE
Make the VM epics-containers compatible

### DIFF
--- a/ansible/roles/docker/tasks/linger.yml
+++ b/ansible/roles/docker/tasks/linger.yml
@@ -1,0 +1,10 @@
+---
+- name: Check if user is lingering
+  stat:
+    path: "/var/lib/systemd/linger/{{ item }}"
+  register: user_lingering
+
+- name: Enable lingering if needed
+  command: "loginctl enable-linger {{ item }}"
+  when: not user_lingering.stat.exists
+  become: yes

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -1,30 +1,33 @@
 ---
+- name: Add docker repository
+  ansible.builtin.yum_repository:
+    name: docker-ce-stable
+    description: official docker stable rpm repo
+    baseurl: https://download.docker.com/linux/fedora/$releasever/$basearch/stable
+    gpgkey: https://download.docker.com/linux/fedora/gpg
+  become: yes
+
 - name: Install RPM prerequisites
   dnf:
     name:
       - podman-docker
-      - python3-pip
+      - dnf-plugins-core
+      - docker-compose-plugin
     state: present
   become: yes
 
-- name: Install PIP prerequisites
-  pip:
-    name: podman-compose
-    state: present
+# linger allows us to set up rootless podman daemons
+- name: Check epics-dev for lingering
+  include_tasks:
+    file: linger.yml
+  with_items: epics-dev
 
 - name: Start and enable podman
   ansible.builtin.systemd:
     name: podman
     state: started
     enabled: yes
-  become: yes
-
-- name: enable podman-restart
-  ansible.builtin.systemd:
-    name: podman-restart
-    state: started
-    enabled: yes
-  become: yes
+    scope: user
 
 - name: Create /etc/containers/nodocker to quiet warning message
   ansible.builtin.file:

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -3,8 +3,8 @@
   ansible.builtin.yum_repository:
     name: docker-ce-stable
     description: official docker stable rpm repo
-    baseurl: https://download.docker.com/linux/fedora/$releasever/$basearch/stable
-    gpgkey: https://download.docker.com/linux/fedora/gpg
+    baseurl: https://download.docker.com/linux/{{ 'centos' if ansible_distribution == 'Rocky' else ansible_distribution | lower }}/$releasever/$basearch/stable
+    gpgkey: https://download.docker.com/linux/{{ 'centos' if ansible_distribution == 'Rocky' else ansible_distribution | lower }}/gpg
   become: yes
 
 - name: Install RPM prerequisites

--- a/update.sh
+++ b/update.sh
@@ -7,7 +7,6 @@
 # - tries the first command line arg or "." as location for the collection
 # - remaining command line args are passed through to ansible-playbook call
 
-# - runs 'git pull --recurse-submodules' on the collection
 # - runs ansible
 
 collection_dir=${1%/}
@@ -36,7 +35,6 @@ else
     slug=""
 fi
 
-( cd ${collection_dir}; git checkout --recurse-submodules ${slug}; git pull --recurse-submodules )
 
 if [ ! -e "${collection_dir}/vm-setup/ansible/group_vars/local.yml" ]; then
     ln -s "../../../local.yml" "${collection_dir}/vm-setup/ansible/group_vars/local.yml"


### PR DESCRIPTION
This makes the following changes to the docker role:
- makes podman rootless
- installs the official docker compose plugin (but with podman back end)
- makes the epics-dev user linger so that it can create user space podman services (that start before user login)

I have chosen to change the existing docker role instead of adding a new epics-containers role because:
- I highly recommend this way of running containers for the majority of use cases
- I spoke to Kunal and he believes the phoebus services would work fine in rootless

Note that we could set things up to switch between rootless and rootful if we have a use case.

Please see https://github.com/gilesknap/training-vm/tree/vagrant for building the Fedora VM using vagrant. Rocky has no official docker rpm repo and the recommendation is to use the centos one, so the fedora repo *might* work with Rocky - will verify later. (I expect that the centos one would work with both so we could use that if we want to support both)
UPDATE: this now works for Rocky and Fedora plus should work for other distros.

To test this PR, launch the training VM and:
```bash
eval "$(curl -L https://raw.githubusercontent.com/epics-training/training-vm/main/bootstrap_redhat.sh)"
cd training/
# get the forked vm version
rm -rf vm-setup/
git clone https://github.com/gilesknap/training-vm --branch epics-containers2 vm-setup
# stop update.sh from overwritting the submodules
sed -i /recurse-submodules/d ../bootstrap/update.sh
# enable the docker role
sed -i 's/#docker/docker/' local.yml
# update the docker role
../bootstrap/update.sh . --tags docker
```

Verify docker compose is working:
```bash
docker compose version
```
should output
```
>>>> Executing external compose provider "/usr/libexec/docker/cli-plugins/docker-compose". Please see podman-compose(1) for how to disable this message. <<<<

Docker Compose version v2.29.7
```

Then verify that epics-containers is working with:
```bash
cd
git clone https://github.com/epics-containers/example-services
cd example-services
. ./environment.sh
docker compose up -d
# should see phoebus showing a moving simdetector image
```
