### PR TITLE
Switch to Debian12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ staging
 ansible/group_vars/local.yml
 @~
 @.bak
+venv
+**/.vagrant

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -1,8 +1,9 @@
 # Default configuration for the available roles
+initial_setup: false
+docker: true # for rootful this needs to happen before first reboot
 epics_modules: true
 catrust: false
 epics_tools: true
-docker: false
 bluesky: false
 
 # Default configuration for the EPICS modules to build

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -2,10 +2,18 @@
 - name: Set up training VM
   hosts: local
   gather_subset: min
+
+  vars:
+    dev_user: "epics_dev"
+
   roles:
     - role: initial_setup
       tags: initial_setup
       when: initial_setup
+
+    - role: docker
+      tags: docker
+      when: docker
 
     - role: catrust
       tags: catrust
@@ -21,10 +29,6 @@
     - role: epics-tools
       tags: epics_tools
       when: epics_tools
-
-    - role: docker
-      tags: docker
-      when: docker
 
     - role: bluesky
       tags: bluesky

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -3,11 +3,15 @@
   hosts: local
   gather_subset: min
   roles:
+    - role: initial_setup
+      tags: initial_setup
+      when: initial_setup
+
     - role: catrust
       tags: catrust
       when: catrust
 
-    - role: common        #  <- mandatory
+    - role: common #  <- mandatory
       tags: common
 
     - role: epics-modules

--- a/ansible/roles/bluesky/tasks/main.yml
+++ b/ansible/roles/bluesky/tasks/main.yml
@@ -12,7 +12,7 @@
     version: "{{ bluesky_container_branch }}"
     clone: yes
     update: yes
-    force: true       # required for update with WORKAROUND (see below)
+    force: true # required for update with WORKAROUND (see below)
   become: no
 
 - name: Create sub-directory (data, user) inside bluesky directory
@@ -32,7 +32,7 @@
   ansible.builtin.template:
     src: run_bluesky.sh.j2
     dest: "{{ bluesky_deployment_dir_path }}/run_bluesky.sh"
-    mode: '755'
+    mode: "755"
   become: no
 
 - name: Ensure the script is executable
@@ -86,62 +86,68 @@
   become: no
 
 - name: Build a Docker formatted image
-  containers.podman.podman_image:
+  community.docker.docker_image:
     name: blueskytraining
-    path: "{{ bluesky_deployment_dir_path }}"
+    source: build
     build:
-      format: docker
+      path: "{{ bluesky_deployment_dir_path }}"
 
 # Needed to determine the used ports further down
 - name: Start context containers
-  command: podman-compose up -d
+  command: docker compose up -d
   args:
     chdir: "{{ bluesky_deployment_dir_path }}"
 
-- name: Add TCP and UDP protocols
-  firewalld:
-    zone: public
-    permanent: yes
-    state: enabled
-    immediate: yes
-    protocol: "{{ item }}"
-  loop:
-    - tcp
-    - udp
-  become: yes
+# the firewall is not running by default and ansible firewalld is not tested
+# for debian distros
 
-- name: tcp ports facts
-  community.general.listen_ports_facts:
+# - name: Add TCP and UDP protocols
+#   firewalld:
+#     zone: public
+#     permanent: yes
+#     state: enabled
+#     immediate: yes
+#     protocol: "{{ item }}"
+#     offline: false
+#   loop:
+#     - tcp
+#     - udp
+#   become: yes
 
-- name: Add ports to firewall
-  firewalld:
-    port: "{{ item }}/tcp"
-    state: enabled
-    immediate: true
-    permanent: true
-  loop: "{{ ansible_facts.tcp_listen  | map(attribute='port') | sort | list }}"
-  register: ports_added_to_firewalld
-  become: yes
+# - name: tcp ports facts
+#   community.general.listen_ports_facts:
 
-- name: print Ports Added
-  debug:
-    var: ports_added_to_firewalld
+# - name: Add ports to firewall
+#   firewalld:
+#     port: "{{ item }}/tcp"
+#     state: enabled
+#     immediate: true
+#     permanent: true
+#     offline: false
+#   loop: "{{ ansible_facts.tcp_listen  | map(attribute='port') | sort | list }}"
+#   register: ports_added_to_firewalld
+#   become: yes
 
-- name: tcp ports facts
-  community.general.listen_ports_facts:
+# - name: print Ports Added
+#   debug:
+#     var: ports_added_to_firewalld
 
-- name: Add ports to firewall
-  firewalld:
-    port: "{{ item }}/udp"
-    state: enabled
-    immediate: true
-    permanent: true
-  loop: "{{ ansible_facts.tcp_listen  | map(attribute='port') | sort | list }}"
-  register: ports_added_to_firewalld
-  become: yes
+# - name: tcp ports facts
+#   community.general.listen_ports_facts:
+
+# - name: Add ports to firewall
+#   firewalld:
+#     port: "{{ item }}/udp"
+#     state: enabled
+#     immediate: true
+#     permanent: true
+#     offline: false
+#   loop: "{{ ansible_facts.tcp_listen  | map(attribute='port') | sort | list }}"
+#   register: ports_added_to_firewalld
+#   become: yes
 
 # Cleanup to avoid interaction with other training modules
 - name: Stop context containers
-  command: podman-compose down
+  command: docker compose down
   args:
     chdir: "{{ bluesky_deployment_dir_path }}"

--- a/ansible/roles/bluesky/templates/run_bluesky.sh.j2
+++ b/ansible/roles/bluesky/templates/run_bluesky.sh.j2
@@ -42,7 +42,7 @@ cleanup() {
     echo "Removing container $target_container and exiting..."
     docker container rm -f "$target_container"
     echo "Stopping context containers"
-    ( cd {{ bluesky_deployment_dir_path }}; podman-compose down )
+    ( cd {{ bluesky_deployment_dir_path }}; docker compose down )
     # Add further cleanup steps if necessary
     exit 1
 }
@@ -59,14 +59,14 @@ case "$command_to_run" in
         echo "Stopping and removing bluesky"
         docker container rm -f "$target_container"
         echo "Stopping context containers"
-        ( cd {{ bluesky_deployment_dir_path }}; podman-compose down )
+        ( cd {{ bluesky_deployment_dir_path }}; docker compose down )
         ;;
     "sh")
         deploy_container sh
         ;;
     *)
         echo "Starting context containers"
-        ( cd {{ bluesky_deployment_dir_path }}; podman-compose up -d )        
+        ( cd {{ bluesky_deployment_dir_path }}; docker compose up -d )        
         # If no command specified, deploy the container
         deploy_container bluesky_start_root
         ;;

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -1,16 +1,9 @@
 ---
-- name: Install common packages
-  dnf: 
-    name: ['gcc-c++']
-    state: latest
-    update_cache: true
-  become: true
-
 - name: Create installation directories
   file:
     path: "{{item}}"
     state: directory
-    mode: '0755'
+    mode: "0755"
   become: true
   loop:
     - "{{ epics_install_path }}"
@@ -18,3 +11,6 @@
     - "{{ epics_install_path }}/epics-tools.sh.d"
     - "{{ epics_install_path }}/.flag"
     - "{{ opi_install_path }}"
+
+- name: gather facts especially cpu cores
+  ansible.builtin.setup:

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -1,42 +1,29 @@
 ---
-- name: Install RPM prerequisites
-  dnf:
-    name:
-      - podman-docker
-      - python3-pip
+- name: Add Docker GPG key
+  apt_key:
+    url: https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg
+  become: yes
+
+- name: Add Docker APT repository
+  apt_repository:
+    repo: deb [arch=amd64] https://download.docker.com/{{ ansible_system | lower }}/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable
+  become: yes
+
+- name: Install Docker
+  ansible.builtin.apt:
+    name: [docker-ce, docker-ce-cli, containerd.io]
     state: present
   become: yes
 
-- name: Install PIP prerequisites
-  pip:
-    name: podman-compose
+- name: create docker group
+  group:
+    name: docker
     state: present
-
-- name: Start and enable podman
-  ansible.builtin.systemd:
-    name: podman
-    state: started
-    enabled: yes
   become: yes
 
-- name: enable podman-restart
-  ansible.builtin.systemd:
-    name: podman-restart
-    state: started
-    enabled: yes
-  become: yes
-
-- name: Create /etc/containers/nodocker to quiet warning message
-  ansible.builtin.file:
-    path: /etc/containers/nodocker
-    state: touch
-    modification_time: preserve
-    access_time: preserve
-  become: yes
-
-- name: quiet compose warning
-  lineinfile:
-    path: /usr/share/containers/containers.conf
-    regexp: ".*compose_warning_logs.*"
-    line: "compose_warning_logs = true"
+- name: add user to docker group
+  user:
+    name: "{{ dev_user }}"
+    groups: docker
+    append: yes
   become: yes

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -33,3 +33,10 @@
     modification_time: preserve
     access_time: preserve
   become: yes
+
+- name: quiet compose warning
+  lineinfile:
+    path: /usr/share/containers/containers.conf
+    regexp: ".*compose_warning_logs.*"
+    line: "compose_warning_logs = true"
+  become: yes

--- a/ansible/roles/epics-modules/README.md
+++ b/ansible/roles/epics-modules/README.md
@@ -28,7 +28,7 @@ and module-specific parameters.
 | release_var     | Variable name to use in the RELEASE file. |
 | release_sortkey | Sort order of RELEASE entries. |
 | add_to_path     | Whether to append the bin directory to teh user's PATH variable. |
-| required_rpms   | List of RPM names of dependencies that need to be installed before the build. |
+| required_packages   | List of RPM names of dependencies that need to be installed before the build. |
 | enable_repos    | List of additional repositories to enable when installing the required RPMs. |
 | pre_hook        | Playbook to run before building the module. |
 | post_hook       | Playbook to run after building the module. |

--- a/ansible/roles/epics-modules/tasks/adcore_prep.yml
+++ b/ansible/roles/epics-modules/tasks/adcore_prep.yml
@@ -2,8 +2,8 @@
 - name: "{{ epics_modules[item].name }} | Fix configure/RELEASE to include RELEASE.local"
   ansible.builtin.lineinfile:
     path: "{{ epics_install_path }}/{{ item }}-{{ epics_modules[item].version }}/configure/RELEASE"
-    search_string: '-include $(TOP)/RELEASE.local'
-    line: '-include $(TOP)/../RELEASE.local'
+    search_string: "-include $(TOP)/RELEASE.local"
+    line: "-include $(TOP)/../RELEASE.local"
   become: true
 
 - name: "{{ epics_modules[item].name }} | Add configuration to configure/CONFIG_SITE"
@@ -17,6 +17,8 @@
       WITH_HDF5 = YES
       WITH_PVA = YES
       XML2_INCLUDE += /usr/include/libxml2
+      HDF5_INCLUDE  = /usr/include/hdf5/serial/
+      HDF5_LIB      = /usr/lib/x86_64-linux-gnu/hdf5/serial/
   become: true
 
 - name: "{{ epics_modules[item].name }} | Common plugins st.cmd snippet"

--- a/ansible/roles/epics-modules/tasks/build_module.yml
+++ b/ansible/roles/epics-modules/tasks/build_module.yml
@@ -1,11 +1,10 @@
 ---
 - name: "{{ epics_modules[item].name }} | Install required dependencies"
-  dnf:
-    name: "{{ epics_modules[item].required_rpms }}"
-    enablerepo: "{{ epics_modules[item].enable_repos | default('[]') }}"
+  ansible.builtin.apt:
+    name: "{{ epics_modules[item].required_packages }}"
     state: present
   become: true
-  when: epics_modules[item].required_rpms is defined
+  when: epics_modules[item].required_packages is defined
 
 - name: "{{ epics_modules[item].name }} | Check global rebuild flag"
   stat:
@@ -54,7 +53,7 @@
     remote_src: true
     extra_opts:
       - --transform
-      - "s|^[^/]*|{{ item }}-{{ epics_modules[item].version }}|"    # normalize source path
+      - "s|^[^/]*|{{ item }}-{{ epics_modules[item].version }}|" # normalize source path
   become: true
   when: epics_module_flag.stat.exists == false
 
@@ -62,7 +61,7 @@
   ansible.builtin.lineinfile:
     path: "{{ epics_install_path }}/{{ item }}-{{ epics_modules[item].version }}/configure/RELEASE"
     state: absent
-    regexp: '^SUPPORT='
+    regexp: "^SUPPORT="
   become: true
 
 - name: "{{ epics_modules[item].name }} | Run pre-build hook"
@@ -70,10 +69,13 @@
   when: epics_modules[item].pre_hook is defined
 
 - name: "{{ epics_modules[item].name }} | Build from sources (this may take a while)"
-  command: make -C "{{ epics_install_path }}/{{ item }}-{{ epics_modules[item].version }}" all clean
+  command: make {{ epics_modules[item]. args | default('') }} -C "{{ epics_install_path }}/{{ item }}-{{ epics_modules[item].version }}" all clean
   register: build_result
   become: true
   when: epics_module_flag.stat.exists == false
+  # the -j cpus occasionally fails !!
+  retries: 1
+  until: build_result.rc == 0
 
 - name: "{{ epics_modules[item].name }} | Run post-build hook"
   include_tasks: "{{ epics_modules[item].post_hook }}"

--- a/ansible/roles/epics-modules/vars/main.yml
+++ b/ansible/roles/epics-modules/vars/main.yml
@@ -1,21 +1,18 @@
 epics_modules:
-
   base:
     name: "EPICS Base"
     version: "7.0.8.1"
-    url: "https://epics-controls.org/download/base/base-7.0.8.1.tar.gz"
+    url: "https://github.com/epics-base/epics-base/releases/download/R7.0.8.1/base-7.0.8.1.tar.gz"
     release_var: "EPICS_BASE"
     release_sortkey: "99"
     add_to_path: true
-    required_rpms:
-      - readline-devel
-      - ncurses-devel
-      - glibc-devel
+    required_packages:
+      - libreadline-dev
+      - libncurses-dev
       - perl
-      - perl-devel
-      - perl-Test-Simple
-      - perl-Test-Harness
+      - libperl-dev
     pre_hook: base_prep.yml
+    args: -j {{ ansible_facts.processor_vcpus }}
 
   pvxs:
     name: "PVXS"
@@ -24,9 +21,10 @@ epics_modules:
     release_var: "PVXS"
     release_sortkey: "10"
     add_to_path: true
-    required_rpms:
-      - libevent-devel
-      - libxml2-devel
+    required_packages:
+      - libevent-dev
+      - libxml2-dev
+    args: -j {{ ansible_facts.processor_vcpus }}
 
   p4p:
     name: "p4p"
@@ -34,13 +32,13 @@ epics_modules:
     url: "https://github.com/epics-base/p4p/archive/refs/tags/4.1.12.tar.gz"
     release_var: "P4P"
     release_sortkey: "10"
-    required_rpms:
-      - python3-devel
+    required_packages:
+      - python3-dev
       - python3-numpy
       - python3-nose2
-      - python3-Cython
-    enable_repos:
-      - crb
+      - python-dev-is-python3
+      - cython3
+    args: -j {{ ansible_facts.processor_vcpus }}
 
   pvapy:
     name: "pvaPy"
@@ -48,16 +46,13 @@ epics_modules:
     url: "https://github.com/epics-base/pvaPy/archive/refs/tags/5.4.1.tar.gz"
     release_var: "PVAPY"
     release_sortkey: "10"
-    required_rpms:
+    required_packages:
       - autoconf
       - automake
-      - python3-devel
-      - boost-python3-devel
-      - boost-numpy3
-      - python3-sphinx
-      - python3-sphinx_rtd_theme
-    enable_repos:
-      - crb
+      - python3-dev
+      - libboost-python-dev
+      - libboost-numpy-dev
+      - python3-sphinx-rtd-theme
     pre_hook: pvapy_prep.yml
     post_hook: pvapy_post.yml
 
@@ -68,7 +63,7 @@ epics_modules:
     release_var: "SNCSEQ"
     release_sortkey: "10"
     add_to_path: true
-    required_rpms:
+    required_packages:
       - re2c
 
   asyn:
@@ -77,18 +72,16 @@ epics_modules:
     url: "https://github.com/epics-modules/asyn/archive/refs/tags/R4-44-2.tar.gz"
     release_var: "ASYN"
     release_sortkey: "10"
-    required_rpms:
-      - rpcgen
-      - libtirpc-devel
-    enable_repos:
-      - crb
+    required_packages:
+      - libtirpc-dev
     pre_hook: asyn_prep.yml
+    args: -j {{ ansible_facts.processor_vcpus }}
 
   autosave:
     name: "autoSaveRestore"
     version: "5.11"
     url: "https://github.com/epics-modules/autosave/archive/refs/tags/R5-11.tar.gz"
-    release_var:  "AUTOSAVE"
+    release_var: "AUTOSAVE"
     release_sortkey: "10"
 
   busy:
@@ -118,15 +111,13 @@ epics_modules:
     url: "https://github.com/areaDetector/ADCore/archive/refs/tags/R3-13.tar.gz"
     release_var: "ADCORE"
     release_sortkey: "10"
-    required_rpms:
-      - zlib-devel
-      - libxml2-devel
-      - libtiff-devel
+    required_packages:
+      - zlib1g-dev
+      - libxml2-dev
+      - libtiff-dev
       - libtiff-tools
-      - libjpeg-devel
-      - hdf5-devel
-    enable_repos:
-      - crb
+      - libjpeg-dev
+      - libhdf5-dev
     pre_hook: adcore_prep.yml
 
   adsimdetector:
@@ -155,4 +146,4 @@ epics_modules:
     release_var: "OPCUA"
     release_sortkey: "10"
     post_hook: opcua_post.yml
-
+    args: -j {{ ansible_facts.processor_vcpus }}

--- a/ansible/roles/initial_setup/tasks/main.yml
+++ b/ansible/roles/initial_setup/tasks/main.yml
@@ -1,0 +1,60 @@
+---
+- name: Upgrade all packages
+  ansible.builtin.dnf:
+    name: "*"
+    state: latest
+  become: yes
+
+- name: Install Development Tools
+  dnf:
+    name:
+      - dkms
+      - kernel-devel
+      - kernel-headers
+      - "@Development Tools"
+  become: yes
+
+# note I cannot convince 'dnf' above to run this style of dnf command
+# which adds 'GNOME' qualifier to the group package install
+- name: Install GNOME
+  command: dnf groupinstall -y "Basic Desktop" GNOME
+  become: yes
+
+- name: Change default target to graphical.target
+  file:
+    src: /usr/lib/systemd/system/graphical.target
+    dest: /etc/systemd/system/default.target
+    state: link
+  become: yes
+
+- name: create user
+  ansible.builtin.user:
+    name: "epics-dev"
+    shell: /bin/bash
+    createhome: yes
+    groups: wheel
+    password: ""
+    comment: "EPICS Developer"
+  become: yes
+
+- name: Make users passwordless for sudo in group wheel
+  lineinfile:
+    path: /etc/sudoers
+    regexp: "^%wheel"
+    line: "%wheel ALL=(ALL) NOPASSWD: ALL"
+    validate: "visudo -cf %s"
+  become: yes
+
+- name: remove services that fail in virtualbox - mcelog
+  ansible.builtin.systemd:
+    name: mcelog
+    state: stopped
+    enabled: no
+  become: yes
+
+- name: remove services that fail in virtualbox - systemd-vconsole
+  ansible.builtin.systemd:
+    name: systemd-vconsole-setup
+    state: stopped
+    enabled: no
+  become: yes

--- a/ansible/roles/initial_setup/tasks/main.yml
+++ b/ansible/roles/initial_setup/tasks/main.yml
@@ -1,23 +1,20 @@
 ---
 - name: Upgrade all packages
-  ansible.builtin.dnf:
+  ansible.builtin.apt:
     name: "*"
     state: latest
+    update_cache: yes
   become: yes
 
-- name: Install Development Tools
-  dnf:
+- name: Install Dev Tools and Gnome
+  ansible.builtin.apt:
     name:
-      - dkms
-      - kernel-devel
-      - kernel-headers
-      - "@Development Tools"
-  become: yes
-
-# note I cannot convince 'dnf' above to run this style of dnf command
-# which adds 'GNOME' qualifier to the group package install
-- name: Install GNOME
-  command: dnf groupinstall -y "Basic Desktop" GNOME
+      - build-essential
+      - git
+      - vim
+      - curl
+      - ansible
+      - gnome-core
   become: yes
 
 - name: Change default target to graphical.target
@@ -29,10 +26,9 @@
 
 - name: create user
   ansible.builtin.user:
-    name: "epics-dev"
+    name: "{{ dev_user }}"
     shell: /bin/bash
     createhome: yes
-    groups: wheel
     password: ""
     comment: "EPICS Developer"
   become: yes
@@ -40,21 +36,7 @@
 - name: Make users passwordless for sudo in group wheel
   lineinfile:
     path: /etc/sudoers
-    regexp: "^%wheel"
-    line: "%wheel ALL=(ALL) NOPASSWD: ALL"
+    regexp: "^%{{ dev_user }}"
+    line: "%{{ dev_user }} ALL=(ALL) NOPASSWD: ALL"
     validate: "visudo -cf %s"
-  become: yes
-
-- name: remove services that fail in virtualbox - mcelog
-  ansible.builtin.systemd:
-    name: mcelog
-    state: stopped
-    enabled: no
-  become: yes
-
-- name: remove services that fail in virtualbox - systemd-vconsole
-  ansible.builtin.systemd:
-    name: systemd-vconsole-setup
-    state: stopped
-    enabled: no
   become: yes

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -11,6 +11,8 @@
 BOOTSTRAP_DIR="bootstrap"
 COLLECTION_DIR="training"
 COLLECTION_REPO=${1:-"https://github.com/epics-training/training-collection"}
+# supply this environment variable to use a different repository for training-vm
+VM_REPO=${VM_REPO:-none}
 
 if [ "$(whoami)" == "root" ]; then
     echo "This script must be run by a regular user (with sudo privileges)."
@@ -39,7 +41,7 @@ fi
 if ! command -v ansible >/dev/null; then
     packages="${packages}ansible"
 fi
-if [ "${packages}" ]; then    
+if [ "${packages}" ]; then
     echo "Installing prerequisites: ${packages}..."
     sudo dnf update
     sudo dnf install -y ${packages}
@@ -63,6 +65,13 @@ fi
 # Set bootstrap soft link
 if [ ! -e "${BOOTSTRAP_DIR}" ]; then
     ln -s "${COLLECTION_DIR}/vm-setup" "${BOOTSTRAP_DIR}"
+fi
+
+if [ "${VM_REPO}" != "none" ]; then
+    echo "Switching training-vm repository to ${VM_REPO}..."
+    rm -fr ${COLLECTION_DIR}/vm-setup
+    git clone ${VM_REPO} ${COLLECTION_DIR}/vm-setup
+    sed -i ${COLLECTION_DIR}/vm-setup/update.sh -e "/recurse-submodules/d"
 fi
 
 # Point out missing local.yml configuration

--- a/doc/creating-vm-from-scratch-apple-silicon.md
+++ b/doc/creating-vm-from-scratch-apple-silicon.md
@@ -1,5 +1,7 @@
 # Creating the EPICS Training VM for Apple Silicon
 
+TODO - requires rework for Debian
+
 These instructions explain how to set up the EPICS training VM
 on Apple Silicon Mac.
 Differing from the normal VM,

--- a/doc/creating-vm-from-scratch.md
+++ b/doc/creating-vm-from-scratch.md
@@ -1,5 +1,7 @@
 # Creating the EPICS Training VM
 
+TODO - requires rework for Debian
+
 These instructions describe how to generate the VirtualBox VM
 for the EPICS Training from scratch.
 The recipe was set up using VirtualBox 7.0.14 on Windows 10,

--- a/doc/vagrant.md
+++ b/doc/vagrant.md
@@ -24,16 +24,23 @@ Setup the required tools on your host machine:
 
 ```bash
 git clone git@github.com:epics-training/training-vm.git
+vagrant plugin install vagrant-vbguest
 cd training-vm/vagrant
-vagrant up
+# start the VM and run the ansible playbook (adjust CPUS to your host)
+VAGRANT_VM_CPUS=14 vagrant up
+# add in the guest additions and reboot to launch the graphical UI
+vagrant vbguest --auto-reboot
 ```
+vbguest step may wait indefinitely for the VM to reboot. If it does, you can manually reboot the VM from the VirtualBox GUI using ACPI shutdown.
 
-When you reboot the VM it will come up with graphical UI and you can login with username epics-dev.
+You can login with username epics-dev, no password.
+
+Before publishing an OVA file, adjust CPUs to a more friendly value for the end user's host machines.
 
 Finally:
 ```bash
 # from inside the VM
-eval "$(curl -L https://raw.githubusercontent.com/epics-training/training-vm/main/bootstrap_redhat.sh)"
+eval "$(curl -L https://raw.githubusercontent.com/epics-training/training-vm/main/bootstrap.sh)"
 ```
 see [creating-vm-from-scratch.md](creating-vm-from-scratch.md) for details regarding the bootstrap script.
 
@@ -49,4 +56,4 @@ vagrant destroy
 ## Skrinking the VM into a small appliance file
 
 TODO
-This will describe how to zero unused blocks and make a small appliance file.
+This will describe how to zero unused blocks and make a smaller appliance file.

--- a/doc/vagrant.md
+++ b/doc/vagrant.md
@@ -1,0 +1,52 @@
+# Vagrant VM Creation
+
+vagrant: making VMs as much fun as containers!
+
+## Introduction
+
+Here are instructions to use vagrant to build the Virtualbox VM as an alternative to [creating-vm-from-scratch.md](creating-vm-from-scratch.md).
+
+Advantages:
+- The VM is created in a reproducible and fully automated way.
+- Its faster because it starts with a pre-built rocky9 base box.
+
+
+## Pre-requisites
+
+Setup the required tools on your host machine:
+1. Install [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
+   - WARNING: VirtualBox 7.1 is not compatible with Vagrant 2.4.1, use VirtualBox 7.0 until Vagrant 2.4.2 is released.
+1. Install [Vagrant](https://www.vagrantup.com/downloads.html)
+1. Install [Ansible](https://docs.ansible.com/ansible/latest/installation_guide/installation_distros.html)
+1. Install [git](https://git-scm.com/downloads)
+
+## Steps
+
+```bash
+git clone git@github.com:epics-training/training-vm.git
+cd training-vm/vagrant
+vagrant up
+```
+
+When you reboot the VM it will come up with graphical UI and you can login with username epics-dev.
+
+Finally:
+```bash
+# from inside the VM
+eval "$(curl -L https://raw.githubusercontent.com/epics-training/training-vm/main/bootstrap_redhat.sh)"
+```
+see [creating-vm-from-scratch.md](creating-vm-from-scratch.md) for details regarding the bootstrap script.
+
+## Troubleshooting
+
+If there is a failure in the ansible steps and you have fixed the issue, re-run the ansible playbook by running `vagrant provision`.
+
+Get rid of the VM by running
+```
+vagrant destroy
+```
+
+## Skrinking the VM into a small appliance file
+
+TODO
+This will describe how to zero unused blocks and make a small appliance file.

--- a/requirements.yml
+++ b/requirements.yml
@@ -2,4 +2,4 @@
 collections:
 - ansible.posix
 - community.general 
-- containers.podman
+- community.docker

--- a/update.sh
+++ b/update.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # update.sh
 
 # Update script that tries to pull the training VM to the appropriate latest versions
@@ -12,7 +12,7 @@
 
 collection_dir=${1%/}
 
-if [ "$(whoami)" == "root" ]; then
+if [[ "$(whoami)" == "root" ]]; then
   echo "This script must be run by a regular user (with sudo privileges)."
   exit 1
 fi

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -10,10 +10,14 @@ Vagrant.configure("2") do |config|
   # For a complete reference, please see the online documentation at
   # https://docs.vagrantup.com.
 
+  if Vagrant.has_plugin?("vagrant-vbguest") then
+    config.vbguest.auto_update = false
+  end
+
   config.vm.define "local" do |local|
     # Every Vagrant development environment requires a box. You can search for
     # boxes at https://vagrantcloud.com/search.
-    local.vm.box = "fedora/40-cloud-base"
+    local.vm.box = "debian/bookworm64"
 
     # Create a private network, which allows host-only access to the machine
     # using a specific IP.
@@ -40,30 +44,25 @@ Vagrant.configure("2") do |config|
     # Provider-specific configuration so you can fine-tune various
     # backing providers for Vagrant. These expose provider-specific options.
     # in this case for VirtualBox:
+
+    cpus = ENV['VAGRANT_VM_CPUS'] || 2
     local.vm.provider "virtualbox" do |vb|
       vb.name = "epics-training"
       vb.gui = true
       vb.customize ["modifyvm", :id, "--ioapic", "on"]
-      vb.customize ["modifyvm", :id, "--cpus", "4"]
+      vb.customize ["modifyvm", :id, "--cpus", cpus]
       vb.customize ["modifyvm", :id, "--vram", "256"]
       # vb.customize ["modifyvm", :id, "--accelerate3d", "on"]
       vb.customize ["modifyvm", :id, "--graphicscontroller", "vmsvga"]
+      vb.customize ["modifyvm", :id, "--clipboard", "bidirectional"]
+      vb.customize ["modifyvm", :id, "--draganddrop", "bidirectional"]
       vb.memory = "4096"
     end
-
-    # resize the original base image disk size
-    local.vm.disk :disk, size: "150GB", primary: true
-
-    # expand the root partition to fill the disk (btrfs specific so not in ansible)
-    local.vm.provision "shell", inline: <<-SHELL
-      growpart /dev/sda 4
-      btrfs filesystem resize 1:max /
-    SHELL
 
     # Provisioning for the EPICS training with initial vagrant VM setup.
     local.vm.provision "ansible" do |ansible|
       ansible.playbook = "../ansible/playbook.yml"
-      ansible.extra_vars = { initial_setup: "true" }
+      ansible.extra_vars = { initial_setup: "true"}
     end
   end
 end

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,0 +1,69 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  config.vm.define "local" do |local|
+    # Every Vagrant development environment requires a box. You can search for
+    # boxes at https://vagrantcloud.com/search.
+    local.vm.box = "fedora/40-cloud-base"
+
+    # Create a private network, which allows host-only access to the machine
+    # using a specific IP.
+    # local.vm.network "private_network", ip: "192.168.33.10"
+
+    # Create a public network, which generally matched to bridged network.
+    # Bridged networks make the machine appear as another physical device on
+    # your network.
+    # local.vm.network "public_network"
+
+    # Share an additional folder to the guest VM. The first argument is
+    # the path on the host to the actual folder. The second argument is
+    # the path on the guest to mount the folder. And the optional third
+    # argument is a set of non-required options.
+    # local.vm.synced_folder "../data", "/vagrant_data"
+
+    # Disable the default share of the current code directory. Doing this
+    # provides improved isolation between the vagrant box and your host
+    # by making sure your Vagrantfile isn't accessible to the vagrant box.
+    # If you use this you may want to enable additional shared subfolders as
+    # shown above.
+    local.vm.synced_folder ".", "/vagrant", disabled: true
+
+    # Provider-specific configuration so you can fine-tune various
+    # backing providers for Vagrant. These expose provider-specific options.
+    # in this case for VirtualBox:
+    local.vm.provider "virtualbox" do |vb|
+      vb.name = "epics-training"
+      vb.gui = true
+      vb.customize ["modifyvm", :id, "--ioapic", "on"]
+      vb.customize ["modifyvm", :id, "--cpus", "4"]
+      vb.customize ["modifyvm", :id, "--vram", "256"]
+      # vb.customize ["modifyvm", :id, "--accelerate3d", "on"]
+      vb.customize ["modifyvm", :id, "--graphicscontroller", "vmsvga"]
+      vb.memory = "4096"
+    end
+
+    # resize the original base image disk size
+    local.vm.disk :disk, size: "150GB", primary: true
+
+    # expand the root partition to fill the disk (btrfs specific so not in ansible)
+    local.vm.provision "shell", inline: <<-SHELL
+      growpart /dev/sda 4
+      btrfs filesystem resize 1:max /
+    SHELL
+
+    # Provisioning for the EPICS training with initial vagrant VM setup.
+    local.vm.provision "ansible" do |ansible|
+      ansible.playbook = "../ansible/playbook.yml"
+      ansible.extra_vars = { initial_setup: "true" }
+    end
+  end
+end


### PR DESCRIPTION
This is marked as draft because it is alternative to and replaces the other two PRs I made.

This adds a vagrant build based on official Debian Bookworm and switches ansible to use DEBs instead of RPMs.

Just now working on the DEB/RPM agnostic version ...

I have squashed the commits down to two:
- Adding Vagrant with Fedora and minimal changes to ansible
- Switching to Debian

This means we have clear starting points to try any DEB or RPM distro.

To test this PR.
- clone this repo
- follow https://github.com/gilesknap/training-vm/blob/vagrant-debian/doc/vagrant.md
- Once the VM is up:-
```bash
VM_REPO="https://github.com/gilesknap/training-vm.git -b debian12" eval "$(curl -L https://raw.githubusercontent.com/gilesknap/training-vm/debian12/bootstrap.sh)"

vim training/local.yml # uncomment choice of roles and modules
./bootstrap/update.sh training
```

I have all the roles and modules building except for pvapy which has some challenges with boost. I'm sure that can be fixed easily enough.

Note that this uses docker rootful instead of podman rootless. Because: https://github.com/epics-training/training-vm/pull/22#issuecomment-2370878140