### PR TITLE
Mutiple vm simultaneous

### DIFF
--- a/doc/vagrant.md
+++ b/doc/vagrant.md
@@ -20,16 +20,16 @@ Setup the required tools on your host machine:
 
 ## Initial Installation
 
-Supported distributions are: debian, fedora, rocky, ubuntu. Set the environment variables `VAGRANT_VM_BOX` to the chosen distrubution and `VAGRANT_VM_CPUS` to the number of CPUS to use in the VM before running `vagrant up`.
+Supported distributions are: debian, fedora, rocky, ubuntu. Set the environment variables `VAGRANT_VM_BOX` to the chosen distrubution and `VAGRANT_VM_CPUS` to the number of CPUS to use in the VM before running `vagrant up`. `VAGRANT_VM_BOX` can also be set to a comma separated list of distributions or `all`.
 
-The defaults are `VAGRANT_VM_BOX=debian` and `VAGRANT_VM_CPUS=4`.
+The defaults are `VAGRANT_VM_BOX=rocky` and `VAGRANT_VM_CPUS=4`.
 
 ```bash
 git clone git@github.com:epics-training/training-vm.git
 vagrant plugin install vagrant-vbguest
 cd training-vm/vagrant
 # start the VM and run the ansible playbook (adjust CPUS to your host)
-VAGRANT_VM_CPUS=14 VAGRANT_VM_BOX=debian vagrant up
+VAGRANT_VM_CPUS=14 VAGRANT_VM_BOX=debian,rocky vagrant up
 vagrant vbguest --auto-reboot
 ```
 

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -3,7 +3,6 @@
 
 
 Vagrant.configure("2") do |config|
-  # docs at https://docs.vagrantup.com.
 
   if Vagrant.has_plugin?("vagrant-vbguest") then
     config.vbguest.auto_update = false
@@ -12,14 +11,6 @@ Vagrant.configure("2") do |config|
   require_relative 'common'
 
   @distros.each do |distro|
-
-    # dont't create this VM unless the distro has been selected for creation
-    if @distro_names.include?(distro[:name]) or @distro_names.include?("all")
-      print "processing #{distro[:name]} #{distro} ...\n"
-    else
-      print "skipping '#{distro[:name]}'\n"
-      next
-    end
 
     config.vm.define distro[:name] do |this|
 

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -9,39 +9,49 @@ Vagrant.configure("2") do |config|
     config.vbguest.auto_update = false
   end
 
-  config.vm.define "local" do |local|
+  require_relative 'common'
 
-    require_relative 'common'
+  @distros.each do |distro|
 
-    # Every Vagrant development environment requires a box. You can search for
-    # boxes at https://vagrantcloud.com/search.
-
-    # resize the original base image disk size
-    local.vm.disk :disk, size: "150GB", primary: true
-
-    local.vm.synced_folder ".", "/vagrant", disabled: true
-    local.vm.synced_folder "../ansible", "/ansible"
-
-    local.vm.box = @distro[:box]
-
-    local.vm.provider "virtualbox" do |vb|
-      # vb.name = "epics-training-" + distro_name
-      vb.gui = true
-      vb.customize ["modifyvm", :id, "--ioapic", "on"]
-      vb.customize ["modifyvm", :id, "--cpus", @cpus]
-      vb.customize ["modifyvm", :id, "--vram", "256"]
-      # vb.customize ["modifyvm", :id, "--accelerate3d", "on"]
-      vb.customize ["modifyvm", :id, "--graphicscontroller", "vmsvga"]
-      vb.customize ["modifyvm", :id, "--clipboard", "bidirectional"]
-      vb.customize ["modifyvm", :id, "--draganddrop", "bidirectional"]
-      vb.memory = "4096"
+    # dont't create this VM unless the distro has been selected for creation
+    if distro[:name]== @distro_name or @distro_name == 'all'
+      print "processing #{distro[:name]} #{distro} ...\n"
+    else
+      print "skipping '#{distro[:name]}'\n"
+      next
     end
 
-    # Install and run guest-side Ansible
-    install_script = File.read("../initial_setup.sh")
-    local.vm.provision "shell" do |s|
-      s.inline = install_script
-      s.env = { ansible_args: ENV['VAGRANT_ANSIBLE_ARGS'] || "", installer: @distro[:installer] }
+    config.vm.define distro[:name] do |this|
+
+      # resize the original base image disk size
+      this.vm.disk :disk, size: "150GB", primary: true
+
+      this.vm.synced_folder ".", "/vagrant", disabled: true
+      this.vm.synced_folder "../ansible", "/ansible"
+
+      this.vm.box = distro[:box]
+      this.vm.hostname = distro[:name]
+      this.vm.network "private_network", ip: distro[:ip]
+
+      this.vm.provider "virtualbox" do |vb|
+        vb.name = "epics-training-" + distro[:name]
+        vb.gui = true
+        vb.customize ["modifyvm", :id, "--ioapic", "on"]
+        vb.customize ["modifyvm", :id, "--cpus", @cpus]
+        vb.customize ["modifyvm", :id, "--vram", "256"]
+        # vb.customize ["modifyvm", :id, "--accelerate3d", "on"]
+        vb.customize ["modifyvm", :id, "--graphicscontroller", "vmsvga"]
+        vb.customize ["modifyvm", :id, "--clipboard", "bidirectional"]
+        vb.customize ["modifyvm", :id, "--draganddrop", "bidirectional"]
+        vb.memory = "4096"
+      end
+
+      # Install and run guest-side Ansible
+      install_script = File.read("../initial_setup.sh")
+      this.vm.provision "shell" do |s|
+        s.inline = install_script
+        s.env = { ansible_args: @ansible_args, installer: distro[:installer] }
+      end
     end
   end
 end

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -14,7 +14,7 @@ Vagrant.configure("2") do |config|
   @distros.each do |distro|
 
     # dont't create this VM unless the distro has been selected for creation
-    if distro[:name]== @distro_name or @distro_name == 'all'
+    if @distro_names.include?(distro[:name]) or @distro_names.include?("all")
       print "processing #{distro[:name]} #{distro} ...\n"
     else
       print "skipping '#{distro[:name]}'\n"
@@ -31,7 +31,6 @@ Vagrant.configure("2") do |config|
 
       this.vm.box = distro[:box]
       this.vm.hostname = distro[:name]
-      this.vm.network "private_network", ip: distro[:ip]
 
       this.vm.provider "virtualbox" do |vb|
         vb.name = "epics-training-" + distro[:name]

--- a/vagrant/common.rb
+++ b/vagrant/common.rb
@@ -1,30 +1,38 @@
+# environment parameters
+@distro_name = ENV['VAGRANT_VM_BOX'] || "rocky"
+@cpus = ENV['VAGRANT_VM_CPUS'] || 4
+@ansible_args = ENV['VAGRANT_ANSIBLE_ARGS'] || ""
 
-distro_name = ENV['VAGRANT_VM_BOX'] || "debian"
-
-distros = {
-  'fedora': {
+@distros = [
+  {
     box: "fedora/40-cloud-base",
     installer: "dnf",
+    ip: "192.168.100.10",
+    name: "fedora"
   },
-  'rocky': {
+  {
     box: "rockylinux/9",
     installer: "dnf",
+    ip: "192.168.100.11",
+    name: "rocky"
   },
-  'debian': {
+  {
     box: "debian/bookworm64",
     installer: "apt",
+    ip: "192.168.100.12",
+    name: "debian"
   },
-  'ubuntu': {
+  {
     box: "ubuntu/focal64",
     installer: "apt",
+    ip: "192.168.100.13",
+    name: "ubuntu"
   },
-}
+]
 
-if not distros.key?(distro_name.to_sym)
-  print "Unknown distro: #{distro_name}, supported distros: #{distros.keys}\n"
+choices = ["fedora", "rocky", "debian", "ubuntu", "all"]
+
+if not choices.include?(@distro_name)
+  print "ERROR: allowed values for VAGRANT_VM_BOX are #{choices}"
   exit 1
 end
-
-@distro = distros[distro_name.to_sym]
-@cpus = ENV['VAGRANT_VM_CPUS'] || 4
-

--- a/vagrant/common.rb
+++ b/vagrant/common.rb
@@ -1,5 +1,4 @@
 # environment parameters
-@distro_names = (ENV['VAGRANT_VM_BOX'] || "rocky").split(',')
 @cpus = ENV['VAGRANT_VM_CPUS'] || 4
 @ansible_args = ENV['VAGRANT_ANSIBLE_ARGS'] || ""
 
@@ -25,12 +24,3 @@
     name: "ubuntu"
   },
 ]
-
-choices = ["fedora", "rocky", "debian", "ubuntu", "all"]
-
-if not @distro_names.all? { |e| choices.include?(e) }
-  print "ERROR: allowed values for VAGRANT_VM_BOX are comma separate distros #{choices} or 'all'"
-  exit 1
-else
-  print "INFO: VAGRANT_VM_BOX is #{@distro_names}"
-end

--- a/vagrant/common.rb
+++ b/vagrant/common.rb
@@ -1,5 +1,5 @@
 # environment parameters
-@distro_name = ENV['VAGRANT_VM_BOX'] || "rocky"
+@distro_names = (ENV['VAGRANT_VM_BOX'] || "rocky").split(',')
 @cpus = ENV['VAGRANT_VM_CPUS'] || 4
 @ansible_args = ENV['VAGRANT_ANSIBLE_ARGS'] || ""
 
@@ -7,32 +7,30 @@
   {
     box: "fedora/40-cloud-base",
     installer: "dnf",
-    ip: "192.168.100.10",
     name: "fedora"
   },
   {
     box: "rockylinux/9",
     installer: "dnf",
-    ip: "192.168.100.11",
     name: "rocky"
   },
   {
     box: "debian/bookworm64",
     installer: "apt",
-    ip: "192.168.100.12",
     name: "debian"
   },
   {
     box: "ubuntu/focal64",
     installer: "apt",
-    ip: "192.168.100.13",
     name: "ubuntu"
   },
 ]
 
 choices = ["fedora", "rocky", "debian", "ubuntu", "all"]
 
-if not choices.include?(@distro_name)
-  print "ERROR: allowed values for VAGRANT_VM_BOX are #{choices}"
+if not @distro_names.all? { |e| choices.include?(e) }
+  print "ERROR: allowed values for VAGRANT_VM_BOX are comma separate distros #{choices} or 'all'"
   exit 1
+else
+  print "INFO: VAGRANT_VM_BOX is #{@distro_names}"
 end


### PR DESCRIPTION
With this PR you can now track multiple distros without deleting the .vagrant folder.

e.g.
```bash
vagrant up rocky debian fedora
```

See https://github.com/epics-training/training-vm/blob/mutiple-vm-simultaneous/doc/vagrant.md#initial-installation