### PR TITLE
Lock epics-tools to a specifc commit (4.6.4 pre release)

### DIFF
--- a/ansible/roles/epics-tools/defaults/main.yml
+++ b/ansible/roles/epics-tools/defaults/main.yml
@@ -6,7 +6,7 @@ epics_services_account: root
 java_home: "/opt/epics-tools/lib/jvm/jdk-17"
 mvn_home: "/opt/epics-tools/lib/apache-maven-3.6.0"
 
-phoebus_version: "master"
+phoebus_version: 8728dbb
 
 phoebus_launcher: "/opt/epics-tools/lib/phoebus/phoebus-product/phoebus.sh"
 phoebus_owner: "root"


### PR DESCRIPTION
As the title suggest, this locks the epics tools to a specific commit ( I am still working on a pre release tag )

This should avoid the issue that @gilesknap encountered with the change in maven version requirements