### PR TITLE
Redesign of bootstrap.sh script

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,14 @@ needed for that training event at the right status (commit).
 ### Create the Virtual Machine
 
 You can create the VM in the traditional manual way.
-Instructions for the rocky flavor are in `doc`.
+The `doc` folder contains
+[instructions for manually creating a Rocky flavour VM](doc/creating-vm-from-scratch.md).
 
 A much faster way is using [Vagrant](https://www.vagrantup.com/),
 which allows for a scripted, automated way to create VirtualBox VMs.
-Instructions (for all four flavours) are also in `doc`.
+In the same folder you will find
+[instructions for creating VMs using Vagrant](doc/vagrant.md)
+(covering all four flavours).
 
 ### Bootstrap the Training-VM
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,85 @@
+# Powerful Flexible Modular Scripted VM-Setup for EPICS
+
+This Training-VM repo contains code (and documentation)
+to set up a virtual machine with EPICS Base and other modules
+in a scripted, reproducible fashion.
+
+The original and main use case are EPICS Training events,
+where each event uses a different set of training modules.
+Nevertheless, the setup can also be used
+to prepare a personal development machine
+or to prepare portable small instances of "control system"
+that can be deployed at collaborators, vendors or customers.
+
+A setup for a specific event can be prepared and updated remotely,
+allowing to distribute an "empty" VM
+that pulls and installs everything needed for a specific training event
+from remote git repos.
+(This install process will take some time - depending on host and setup -
+typically under an hour.)
+
+To minimize the install time,
+a "fully installed" VM can also be distributed,
+keeping the possibility to update the content at any time
+with last-minute changes.
+
+## VM Options
+
+We are using [VirtualBox](https://www.oracle.com/virtualization/virtualbox/),
+which can be run on Linux, Windows and Mac hosts.
+
+The Training-VM is available in four flavours in their stable/current versions:
+- rocky: [RockyLinux](https://rockylinux.org/) (compatible to RHEL)
+- fedora: [Fedora Linux](https://fedoraproject.org/)
+- debian: the "stable" release of [Debian Linux](https://www.debian.org/)
+- ubuntu: [Ubuntu Linux](https://ubuntu.com/)
+
+Not all modules are working on all flavours. 
+
+Not all modules are working on Mac using Apple Silicon processors.
+
+## Repository Structure
+
+Everything needed for a specific training event,
+the vm setup (this repo) as well as the training modules (slides and examples),
+is installed as git submodules of a parent, called the "collection".
+
+The collection repo contains a branch for each training event, named after it.
+Any vm instance is configured
+by specifying the "slug" (short name) of the training event it is used for.
+
+That branch of the collection contains exactly all modules and configuration
+needed for that training event at the right status (commit).
+
+## Workflow
+
+### Create the Virtual Machine
+
+You can create the VM in the traditional manual way.
+Instructions for the rocky flavor are in `doc`.
+
+A much faster way is using [Vagrant](https://www.vagrantup.com/),
+which allows for a scripted, automated way to create VirtualBox VMs.
+Instructions (for all four flavours) are also in `doc`.
+
+### Bootstrap the Training-VM
+
+Once your VM is up, run the script `bootstrap.sh`.
+
+This will ask for the slug of the training event
+you want to install the VM for
+(i.e., the branch of the collection repo),
+download dependencies (git, ansible, ...),
+and clone the specified branch of the collection repo.
+
+### Run the `vm-setup/update.sh` Script
+
+This script can be run at any time to pull and install
+the latest changes in the setup.
+
+It updates the collection's submodules
+and calls Ansible to run through the install.
+
+The Ansible scripts are optimized for execution time
+(skipping parts that are already installed and unchanged),
+to make the update a light and fast procedure.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ In the same folder you will find
 ### Bootstrap the Training-VM
 
 Once your VM is up, run the script `bootstrap.sh`.
+```bash
+# from inside the VM
+eval "$(curl -L https://raw.githubusercontent.com/epics-training/training-vm/main/bootstrap.sh)"
+```
 
 This will ask for the slug of the training event
 you want to install the VM for
@@ -81,7 +85,7 @@ This script can be run at any time to pull and install
 the latest changes in the setup.
 
 It updates the collection's submodules
-and calls Ansible to run through the install.
+and calls Ansible to run the installation procedure.
 
 The Ansible scripts are optimized for execution time
 (skipping parts that are already installed and unchanged),

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -42,6 +42,21 @@ COLLECTION=${COLLECTION:-"training"}
 SLUGFILE=${SLUGFILE:-"/etc/epics-training"}
 COLLECTION_REPO=${COLLECTION_REPO:-"https://github.com/epics-training/training-collection"}
 
+# Install prerequisites: Git, Ansible
+if ! command -v git >/dev/null; then
+    packages="git"
+fi
+if ! command -v ansible >/dev/null; then
+    packages="${packages} ansible"
+fi
+if [ "${packages}" ]; then
+    echo "Installing prerequisites: ${packages}..."
+    sudo dnf update
+    sudo dnf install -y ${packages}
+else
+    echo "All prerequisites are installed."
+fi
+
 # if SLUG is not set, read it from SLUGFILE or ask for it
 if [ ! "${SLUG}" ]; then
     if [ ! -e "${SLUGFILE}" ]; then
@@ -63,21 +78,6 @@ if [ ! "${SLUG}" ]; then
     else
         SLUG=$(<${SLUGFILE})
     fi
-fi
-
-# Install prerequisites: Git, Ansible
-if ! command -v git >/dev/null; then
-    packages="git"
-fi
-if ! command -v ansible >/dev/null; then
-    packages="${packages} ansible"
-fi
-if [ "${packages}" ]; then
-    echo "Installing prerequisites: ${packages}..."
-    sudo dnf update
-    sudo dnf install -y ${packages}
-else
-    echo "All prerequisites are installed."
 fi
 
 # Clone the collection

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -45,12 +45,12 @@ COLLECTION_REPO=${COLLECTION_REPO:-"https://github.com/epics-training/training-c
 # if SLUG is not set, read it from SLUGFILE or ask for it
 if [ ! "${SLUG}" ]; then
     if [ ! -e "${SLUGFILE}" ]; then
-        slugs=$(git ls-remote --heads ${COLLECTION_REPO} | awk -F / '{ print $3 }')
+        slugs=$(git ls-remote --heads ${COLLECTION_REPO} | awk -F / '{ print "\\t" $3 "\\n" }')
         echo "Using collection repo at ${COLLECTION_REPO}"
         echo "Please specify the slug (short name) of the event"
         echo "that you want to configure this machine for."
         echo "Valid strings (branches in the collection repo) are:"
-        echo $slugs
+        echo -en $slugs
         echo "Leaving the slug empty will use the default branch with all available submodules."
         echo "For development, you can switch submodules to use direct checkouts"
         echo "using settings in the 'bootstrap_setup' file."

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,45 +1,73 @@
-#!/bin/sh
+#!/bin/bash
 # bootstrap.sh
 
-# Simple bootstrap script for RedHat family systems (developed on Rocky 9)
+# Bootstrap script for training-vm based systems
+# - reads local settings
 # - installs prerequisites: git, ansible
-# - clones training-collection repo into ./training
-# - sets soft link bootstrap -> training/vm-setup
+# - clones collection repo into collection subdir (with submodules)
+# - creates/links Ansible configuration local.yml
 
-# $1 = repo (default: GitHub)
-
-BOOTSTRAP_DIR="bootstrap"
-COLLECTION_DIR="training"
-COLLECTION_REPO=${1:-"https://github.com/epics-training/training-collection"}
-# supply this environment variable to use a different repository for training-vm
-VM_REPO=${VM_REPO:-none}
+# $1 = settings file (default: ./bootstrap_setup or ~/bootstrap_setup)
 
 if [ "$(whoami)" == "root" ]; then
     echo "This script must be run by a regular user (with sudo privileges)."
     exit 1
 fi
 
-if [ ! -e "/etc/epics-training" ]; then
-    echo "Please specify the slug (short name) of the training course that you"
-    echo "want to configure this machine for."
-    echo "See https://github.com/epics-training/training-collection for valid strings."
-    echo "Leaving it empty will use the latest versions of all available training modules."
-    echo "(This is recommended for development of the training environment.)"
-    read -p "Training course name []: " slug
-    TMP_FILE=$(mktemp -q /tmp/epics.XXXXXX)
-    echo "$slug" > $TMP_FILE
-    sudo cp $TMP_FILE /etc/epics-training
-    sudo chmod 644 /etc/epics-training
+# Associative arrays to configure developer mode
+declare -A REPO BRANCH
+
+# Read configuration file "$1", ./bootstrap_setup or ~/bootstrap_setup
+echo -n "Reading configuration"
+if [ "$1" ]; then
+    if [ -e "$1" ]; then 
+        source "$1"
+        echo " from $1"
+    else
+        echo " [ERROR: file $1 not found]"
+        exit 1
+    fi    
+elif [ -e ./bootstrap_setup ]; then
+    source ./bootstrap_setup
+    echo " from ./bootstrap_setup"
+elif [ -e ~/bootstrap_setup ]; then
+    source ~/bootstrap_setup
+    echo " from ~/bootstrap_setup"
 fi
 
-slug=$(</etc/epics-training)
+# Override these defaults in your 'bootstrap_setup' file
+# Switch submodule $COLLECTION/xyz to direct checkout by setting
+# REPO[xyz] (and BRANCH[xyz]
+COLLECTION=${COLLECTION:-"training"}
+SLUGFILE=${SLUGFILE:-"/etc/epics-training"}
+COLLECTION_REPO=${COLLECTION_REPO:-"https://github.com/epics-training/training-collection"}
+
+# if SLUG is not set, read it from SLUGFILE or ask for it
+if [ ! "${SLUG}" ]; then
+    if [ ! -e "${SLUGFILE}" ]; then
+        echo "Please specify the slug (short name) of the event that you"
+        echo "want to configure this machine for."
+        echo "See ${COLLECTION_REPO} branches for valid strings."
+        echo "Leaving it empty will use the default branch with all available submodules."
+        echo "For development, you can switch submodules to use direct checkouts"
+        echo "through settings in the 'bootstrap_setup' file."
+        echo "The slug will be written to ${SLUGFILE}."
+        read -p "Event name []: " SLUG
+        TMP_FILE=$(mktemp -q /tmp/epics.XXXXXX)
+        echo "$SLUG" > $TMP_FILE
+        sudo cp $TMP_FILE ${SLUGFILE}
+        sudo chmod 644 ${SLUGFILE}
+    else
+        SLUG=$(<${SLUGFILE})
+    fi
+fi
 
 # Install prerequisites: Git, Ansible
 if ! command -v git >/dev/null; then
-    packages="git "
+    packages="git"
 fi
 if ! command -v ansible >/dev/null; then
-    packages="${packages}ansible"
+    packages="${packages} ansible"
 fi
 if [ "${packages}" ]; then
     echo "Installing prerequisites: ${packages}..."
@@ -49,36 +77,56 @@ else
     echo "All prerequisites are installed."
 fi
 
-# Clone the training-collection
-if [ ! -e "${COLLECTION_DIR}" ]; then
+# Clone the collection
+if [ ! -e "${COLLECTION}" ]; then
     branch=""
-    if [ "$slug" ]; then
-        branch="-b $slug"
+    if [ "$SLUG" ]; then
+        branch="-b $SLUG"
     fi
-    echo "Cloning training-collection ($slug) into ./${COLLECTION_DIR}..."
-    git clone --recurse-submodules $branch ${COLLECTION_REPO} ${COLLECTION_DIR}
+    echo "Cloning collection (for $SLUG) into ./${COLLECTION}..."
+    git clone $branch ${COLLECTION_REPO} ${COLLECTION}
 else
-    echo "Update the existing training-vm configuration by running 'git pull' in ./${COLLECTION_DIR}."
-    echo "Switch the training setup with 'git checkout \$(</etc/epics-training)' in ./${COLLECTION_DIR}."
+    echo "Update the existing VM configuration by running 'git pull' in ./${COLLECTION_DIR}."
+    echo "Switch the setup with 'git checkout \$(<${SLUGFILE})' in ./${COLLECTION_DIR}."
 fi
 
-# Set bootstrap soft link
-if [ ! -e "${BOOTSTRAP_DIR}" ]; then
-    ln -s "${COLLECTION_DIR}/vm-setup" "${BOOTSTRAP_DIR}"
-fi
+cd ${COLLECTION}
+modules=$(git submodule | awk '{ print $2 }')
 
-if [ "${VM_REPO}" != "none" ]; then
-    echo "Switching training-vm repository to ${VM_REPO}..."
-    rm -fr ${COLLECTION_DIR}/vm-setup
-    git clone ${VM_REPO} ${COLLECTION_DIR}/vm-setup
-    sed -i ${COLLECTION_DIR}/vm-setup/update.sh -e "/recurse-submodules/d"
-fi
+echo "Adding submodules into ${COLLECTION} ..."
+
+for mod in ${modules}; do
+    repo="${REPO[${mod}]}"
+    branch="${BRANCH[${mod}]}"
+    if [ "$repo" ]; then
+        if [ "$branch" ]; then
+            extra="-b $branch"
+        fi
+        echo "Removing submodule $mod ..."
+        git submodule deinit -f $mod
+        rm -rf .git/modules/$mod $mod
+        git rm -f $mod
+        echo "Cloning $mod from $repo ..."
+        git clone $extra $repo $mod
+    else
+        git submodule update --init $mod
+    fi
+done
 
 # Point out missing local.yml configuration
-if [ ! -e "${COLLECTION_DIR}/vm-setup/ansible/group_vars/local.yml" ]; then
-    ln -s "../../../local.yml" "${COLLECTION_DIR}/vm-setup/ansible/group_vars/local.yml"
+if [ ! -e "vm-setup/ansible/group_vars/local.yml" ]; then
+    if [ ! -e "local.yml" ]; then
+        echo "No local configuration found. Creating one from local.yml.sample"
+        cp "vm-setup/ansible/group_vars/local.yml.sample" "local.yml"
+    fi
+    ln -s "../../../local.yml" "vm-setup/ansible/group_vars/local.yml"
 else
-    echo "Verify your existing local configuration in ${BOOTSTRAP_DIR}/ansible/group_vars/local.yml"
+    echo -n "Verify your existing local configuration"
+    if [ -h "vm-setup/ansible/group_vars/local.yml" ]; then
+        echo " in ${COLLECTION}/local.yml"
+    else
+        echo " in ${COLLECTION}/vm-setup/ansible/group_vars/local.yml"
+    fi
 fi
 
-echo "Run ${BOOTSTRAP_DIR}/update.sh at any time to update your installation."
+echo "Run ${COLLECTION}/vm-setup/update.sh at any time to finish or update your installation."

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -45,12 +45,15 @@ COLLECTION_REPO=${COLLECTION_REPO:-"https://github.com/epics-training/training-c
 # if SLUG is not set, read it from SLUGFILE or ask for it
 if [ ! "${SLUG}" ]; then
     if [ ! -e "${SLUGFILE}" ]; then
-        echo "Please specify the slug (short name) of the event that you"
-        echo "want to configure this machine for."
-        echo "See ${COLLECTION_REPO} branches for valid strings."
-        echo "Leaving it empty will use the default branch with all available submodules."
+        slugs=$(git ls-remote --heads ${COLLECTION_REPO} | awk -F / '{ print $3 }')
+        echo "Using collection repo at ${COLLECTION_REPO}"
+        echo "Please specify the slug (short name) of the event"
+        echo "that you want to configure this machine for."
+        echo "Valid strings (branches in the collection repo) are:"
+        echo $slugs
+        echo "Leaving the slug empty will use the default branch with all available submodules."
         echo "For development, you can switch submodules to use direct checkouts"
-        echo "through settings in the 'bootstrap_setup' file."
+        echo "using settings in the 'bootstrap_setup' file."
         echo "The slug will be written to ${SLUGFILE}."
         read -p "Event name []: " SLUG
         TMP_FILE=$(mktemp -q /tmp/epics.XXXXXX)

--- a/doc/vagrant.md
+++ b/doc/vagrant.md
@@ -116,6 +116,35 @@ then re-run the Ansible playbook:
 $ vm-setup/update.sh
 ```
 
+## Extended Configuration Options
+
+To support development,
+the behaviour of the `bootstrap.sh` script can be adapted
+using a bootstrap setup file that is sourced by the script.
+
+Create a file using the default name `~/bootstrap_setup`
+that contains settings in bash syntax.
+
+- `COLLECTION`: name of the directory for clone the collection into
+  (default `training`)
+- `COLLECTION_REPO`: URL of the repo to clone for the collection
+  (default: `https://github.com/epics-training/training-collection`)
+- `SLUGFILE`: file to store the slug (branch) name
+  (default: `/etc/epics-training`)
+
+You can redirect any of the submodules
+to be directly cloned from a different location.
+E.g., to clone the `vm-setup` submodule
+from johndoe's fork of the `training-vm` repo (`test-feature` branch):
+```
+REPO[vm-setup]=https://github.com/johndoe/training-vm
+BRANCH[vm-setup]=test-feature
+```
+
+The `bootstrap.sh` script
+can take the name of a bootstrap setup file as parameter.
+This allows to have different setups in parallel collection directories.
+
 ## Troubleshooting
 
 If there is a failure in the Ansible steps and you have fixed the issue,
@@ -130,6 +159,9 @@ vagrant destroy
 # or just two distros
 vagrant destroy rocky ubuntu
 ```
+
+You may need to also manually remove a VM's directory
+before you can recreate the same VM from scratch.
 
 SSH into the rocky VM:
 ```


### PR DESCRIPTION
Updates the `bootstrap.sh` script to adapt it to current practices and to make it more generic.

- remove unnecessary `bootstrap` directory
- load bootstrap settings from configuration file
  (specified as $1 or `./bootstrap_setup` or `~/bootstrap_setup`)
- configurable COLLECTION (name for the collection directory), COLLECTION_REPO (URL to clone the collection from) and SLUGFILE (file to keep the event name = branch of the collection repo)
- allow proper replacement of any submodule with direct clone of different (development) repo/branch
