### PR TITLE
base box: update ubuntu to use bento/ubunto24.04

### DIFF
--- a/vagrant/common.rb
+++ b/vagrant/common.rb
@@ -19,7 +19,7 @@
     name: "debian"
   },
   {
-    box: "ubuntu/focal64",
+    box: "bento/ubuntu-24.04",
     installer: "apt",
     name: "ubuntu"
   },


### PR DESCRIPTION
Following the general trend... bump Ubuntu version to 24.04