### PR TITLE
Rework the CA Trust function for Vagrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ ansible/group_vars/local.yml
 @.bak
 venv
 **/.vagrant
+/vagrant/corporate_root_ca.crt

--- a/ansible/roles/catrust/tasks/main.yml
+++ b/ansible/roles/catrust/tasks/main.yml
@@ -49,18 +49,41 @@
     state: directory
   become: true
 
+- name: Check for Vagrant-injected certificate
+  ansible.builtin.stat:
+    path: "{{ ca_temp_path }}"
+  register: temp_cert
+
 - name: Download ROOT CA Certificate
   ansible.builtin.get_url:
     url: "{{ root_ca_url }}"
-    dest: "{{ ca_trust_der_path }}"
+    dest: "{{ ca_temp_path }}"
     validate_certs: false
   become: true
   register: get_url_result
+  when: root_ca_url is defined
+
+- name: Check type of downloaded ROOT CA certificate
+  ansible.builtin.command: grep -q -- "-----BEGIN CERTIFICATE-----" "{{ ca_temp_path}}"
+  register: check_pem
+  failed_when: check_pem.rc != 0 and check_pem.rc != 1
+  check_mode: false
+  changed_when: false
+  when: temp_cert.stat.exists or get_url_result.changed
 
 - name: Convert DER certificate to PEM
-  command: openssl x509 -inform DER -in '{{ ca_trust_folder }}/corporate_root_ca.der.crt' -out '{{ ca_trust_pem_path }}' -outform PEM
+  ansible.builtin.shell: |
+    openssl x509 -inform DER -in {{ ca_temp_path }} -out {{ ca_trust_pem_path }} -outform PEM
+    cp -f {{ ca_temp_path }} {{ ca_trust_der_path }}
   become: true
-  when: get_url_result.changed
+  when: check_pem.rc == 1
+
+- name: Convert PEM certificate to DER
+  ansible.builtin.shell: |
+    openssl x509 -inform PEM -in {{ ca_temp_path }} -out {{ ca_trust_der_path }} -outform DER
+    cp -f {{ ca_temp_path }} {{ ca_trust_pem_path }}
+  become: true
+  when: check_pem.rc == 0
 
 - name: Copy PEM certificate to system ca trust directory
   ansible.builtin.copy:

--- a/ansible/roles/catrust/tasks/main.yml
+++ b/ansible/roles/catrust/tasks/main.yml
@@ -1,3 +1,48 @@
+# Allow unsafe legacy renegotiation via openssl configuration
+# RedHat: on global level
+# Debian: in section [openssl_init]/[ssl_sect]/[system_default_sect]
+
+- name: Allow UnsafeLegacyRenegotiation to support corporate proxy
+  community.general.ini_file:
+    path: "{{ distro.openssl_config }}"
+    option: Options
+    value: UnsafeLegacyRenegotiation
+    state: present
+  become: true
+  when: is_redhat
+
+- name: Allow UnsafeLegacyRenegotiation to support corporate proxy [openssl_init]
+  community.general.ini_file:
+    path: "{{ distro.openssl_config }}"
+    section: openssl_init
+    option: ssl_conf
+    value: ssl_sect
+    state: present
+  become: true
+  when: is_debian
+
+- name: Allow UnsafeLegacyRenegotiation to support corporate proxy [ssl_sect]
+  community.general.ini_file:
+    path: "{{ distro.openssl_config }}"
+    section: ssl_sect
+    option: system_default 
+    value: system_default_sect
+    state: present
+  become: true
+  when: is_debian
+
+- name: Allow UnsafeLegacyRenegotiation to support corporate proxy [system_default_sect]
+  community.general.ini_file:
+    path: "{{ distro.openssl_config }}"
+    section: system_default_sect
+    option: Options  
+    # UnsafeLegacyRenegotiation for ubuntu <= 22.04
+    # UnsafeLegacyServerConnect for ubuntu >= 24.04
+    value: UnsafeLegacyRenegotiation,UnsafeLegacyServerConnect
+    state: present
+  become: true
+  when: is_debian
+
 - name: Creates ca_trust cache directory
   ansible.builtin.file:
     path: "{{ ca_trust_folder }}"
@@ -8,6 +53,7 @@
   ansible.builtin.get_url:
     url: "{{ root_ca_url }}"
     dest: "{{ ca_trust_der_path }}"
+    validate_certs: false
   become: true
   register: get_url_result
 
@@ -26,12 +72,4 @@
 - name: Update trusted ca certificates
   command: "{{ distro.system_ca_trust_update }}"
   when: copy_result.changed
-  become: true
-
-- name: Allow UnsafeLegacyRenegotiation to support corporate proxy
-  community.general.ini_file:
-    path: /etc/crypto-policies/back-ends/opensslcnf.config
-    option: Options
-    value: UnsafeLegacyRenegotiation
-    state: present
   become: true

--- a/ansible/roles/catrust/vars/main.yml
+++ b/ansible/roles/catrust/vars/main.yml
@@ -1,0 +1,10 @@
+# [catrust] Use self-signed CA certificate to work through corporate firewall
+# with deep packet inspection (e.g., f5)
+
+# In local.yml, set the URL for the certificate (PEM or DER)
+#root_ca_url: "http://pki.iter.org/CertEnroll/io-ws-pkiroot_ITER%20Organization%20Root%20CA.crt"
+
+ca_trust_folder: "/var/lib/training-vm/ca_trust"
+ca_temp_path: "/tmp/corporate_root_ca.crt"
+ca_trust_der_path: "{{ ca_trust_folder }}/corporate_root_ca.der.crt"
+ca_trust_pem_path: "{{ ca_trust_folder }}/corporate_root_ca.pem.crt"

--- a/ansible/roles/epics-tools/tasks/install_java.yml
+++ b/ansible/roles/epics-tools/tasks/install_java.yml
@@ -28,6 +28,12 @@
       - --strip-components=1
   when: java_installation.stat.exists == false
 
+- name: Check if CA certificate (DER format) exists
+  ansible.builtin.stat:
+    path: "{{ ca_trust_der_path }}"
+  register: ca_cert_der
+  changed_when: false
+
 - name: Add CA certificate to java trust store
   community.general.java_cert:
     cert_path: "{{ ca_trust_der_path }}"
@@ -39,7 +45,7 @@
   become: true
   environment:
     PATH: "{{ java_home }}/bin:{{ ansible_env.PATH }}"
-  when: ca_trust_der_path is defined
+  when: ca_cert_der.stat.exists
 
 # Install open maven
 - name: ensure mvn directory exists

--- a/ansible/roles/initial_setup/tasks/main.yml
+++ b/ansible/roles/initial_setup/tasks/main.yml
@@ -35,16 +35,18 @@
       - vim
       - curl
       - sudo
+      - openssl
       - "{{ distro.gnome_group }}"
   become: true
   when: is_debian
 
-- name: RPM Install Development Tools
+- name: RPM Install Dev Tools and Gnome
   dnf:
     name:
       - "@Development Tools"
       - vim
       - sudo
+      - openssl
       - "@{{ distro.gnome_group }}"
     allowerasing: true # fix version conflicts for curl and coreutils on Rocky
   become: true

--- a/doc/bootstrap-update-vm.md
+++ b/doc/bootstrap-update-vm.md
@@ -31,6 +31,12 @@ as a copy of the sample file
 Edit `local.yml` to configure your training VM,
 then update your Training-VM.
 
+### Adding a CA Certificate
+
+If your institute firewall requires an additional CA certificate,
+enable the `catrust` role
+and set the URL for downloading the certificate (in PEM or DER format).
+
 ## Update - Run When Necessary to Update the Setup
 
 The `update.sh` script can be run at any time

--- a/doc/creating-vm-using-vagrant.md
+++ b/doc/creating-vm-using-vagrant.md
@@ -81,6 +81,13 @@ You can login with username `epics-dev`, no password.
 Before publishing an OVA file,
 adjust CPUs to a more friendly value for the end user's host machine.
 
+### Adding a CA Certificate
+
+If your institute firewall requires an additional CA certificate,
+copy the required certificate (in PEM format)
+into the `vagrant` directory (next to the `Vagrantfile`)
+and enable the `catrust` role (in the bootstrap step).
+
 ## Add the Training Specific Content: Bootstrap and Update
 
 The initial installation is a minimal VM.

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -47,7 +47,7 @@ Vagrant.configure("2") do |config|
         vb.customize ["storageattach", :id, "--storagectl", "IDE Controller", "--device", "0", "--port", "0", "--medium", "emptydrive"]
       end
 
-      # Install corporate root CA certificate (PEM format)
+      # Install corporate root CA certificate (PEM or DER format)
       # if it exists here as 'corporate_root_ca.crt'
       if File.exist?("corporate_root_ca.crt")
         this.vm.provision "file", source: "corporate_root_ca.crt", destination: "corporate_root_ca.crt"

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -47,9 +47,19 @@ Vagrant.configure("2") do |config|
         vb.customize ["storageattach", :id, "--storagectl", "IDE Controller", "--device", "0", "--port", "0", "--medium", "emptydrive"]
       end
 
+      # Install corporate root CA certificate (PEM format)
+      # if it exists here as 'corporate_root_ca.crt'
+      if File.exist?("corporate_root_ca.crt")
+        this.vm.provision "file", source: "corporate_root_ca.crt", destination: "corporate_root_ca.crt"
+        catrust_script = File.read("ca-trust.sh")
+        this.vm.provision "trust corporate ca", type: "shell" do |s|
+          s.inline = catrust_script
+        end
+      end
+
       # Install and run guest-side Ansible
       install_script = File.read("../initial_setup.sh")
-      this.vm.provision "shell" do |s|
+      this.vm.provision "initial setup", type: "shell" do |s|
         s.inline = install_script
         s.env = { ansible_args: @ansible_args, installer: distro[:installer] }
       end

--- a/vagrant/ca-trust.sh
+++ b/vagrant/ca-trust.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+#
+# Run as root
+# Adds the necessary configuration into a VM that allows
+# connecting through a corporate firewall doing deep packet inspection
+#
+# Needs the root CA certificate (in PEM format)
+# in the current directory as ./corporate_root_ca.crt
+
+# Function to add a line to a specific section in a configuration file
+# or add it at the end of the file (when no section is specified)
+add_line_to_section() {
+  local config_file="$1"
+  local section_name="$2"
+  local new_line="$3"
+  local section_found=0
+
+  if [[ "$section_name" == "" ]]; then
+    echo "$new_line" >> "$config_file"
+  else
+    temp_file=$(mktemp)
+    
+    # Read the configuration file line by line
+    while IFS= read -r line; do
+      # Check if the line is the beginning of the specified section
+      grep -q "^\[\W*$section_name\W*\]" <<< $line 
+      if [ $? -eq 0 ]; then
+        # Write the section header and the new line to the temporary file
+        echo "$line" >> "$temp_file"
+        echo "$new_line" >> "$temp_file"
+        section_found=1
+      else
+        # Write the current line to the temporary file
+        echo "$line" >> "$temp_file"
+      fi
+    done < "$config_file"
+
+    if [[ $section_found -eq 0 ]]; then
+      echo \[" $section_name "\] >> "$temp_file"
+      echo "$new_line" >> "$temp_file"
+    fi
+
+    mv "$temp_file" "$config_file"
+  fi
+}
+
+if [ ! -e "corporate_root_ca.crt" ]; then
+  echo "No corporate_root_ca.crt file found"
+  exit 1
+fi
+
+if [ -e /etc/debian_version ]; then
+  # Debian / Ubuntu
+  cfg=/etc/ssl/openssl.cnf
+  grep "ssl_conf\W*=\W*ssl_sect" $cfg \
+    || add_line_to_section $cfg openssl_init "ssl_conf = ssl_sect"
+  grep "system_default\W*=\W*system_default_sect" $cfg \
+    || add_line_to_section $cfg ssl_sect "system_default = system_default_sect"
+  grep "Options\W*=\W*UnsafeLegacyRenegotiation,UnsafeLegacyServerConnect" $cfg \
+    || add_line_to_section $cfg system_default_sect "Options = UnsafeLegacyRenegotiation,UnsafeLegacyServerConnect"
+  cp corporate_root_ca.crt /usr/local/share/ca-certificates/
+  /usr/sbin/update-ca-certificates
+else
+  # Rocky / Fedora
+  cfg=/etc/crypto-policies/back-ends/opensslcnf.config
+  grep "Options\W*=\W*UnsafeLegacyRenegotiation" $cfg \
+    || add_line_to_section $cfg "" "Options = UnsafeLegacyRenegotiation"
+  cp corporate_root_ca.crt /etc/pki/ca-trust/source/anchors/
+  /usr/bin/update-ca-trust
+fi


### PR DESCRIPTION
https access is needed in the Vagrant build before the Ansible mechanism is run.

To be able to build VMs with Vagrant behind a corporate firewall, the SSL-relevant part of the `ca-trust` role mechanics was additionally implemented in a bash script run in the beginning of the Vagrant build.

Instructions:
Add the PEM format CA certificate in the `vagrant` folder as `corporate_root_ca.crt`. Vagrant will detect the file and add it to the guest system's OpenSSL certificate store before running the package manager for the first time.
The `ca-trust` role also needs to be enabled to allow installing the certificate (converted to DER) for Java.