### PR TITLE
Improve CI workflows

### DIFF
--- a/.github/workflows/Containerfile.fedora
+++ b/.github/workflows/Containerfile.fedora
@@ -3,7 +3,8 @@ ARG IMAGE=fedora:latest
 FROM ${IMAGE}
 
 RUN dnf install -y epel-release || dnf update -y --refresh
-RUN dnf install -y git python3-pip python3-jmespath ansible
+RUN dnf install -y git python3-pip python3-jmespath ansible \
+ && dnf clean all && rm -rf /var/cache/{yum,dnf}
 RUN pip3 install ansible-lint
 
 COPY ansible /ansible

--- a/.github/workflows/Containerfile.rocky
+++ b/.github/workflows/Containerfile.rocky
@@ -3,7 +3,8 @@ ARG IMAGE=rockylinux:latest
 FROM $IMAGE
 
 RUN dnf install -y epel-release || dnf update -y --refresh
-RUN dnf install -y git python3-pip python3-jmespath ansible
+RUN dnf install -y git python3-pip python3-jmespath ansible \
+ && dnf clean all && rm -rf /var/cache/{yum,dnf}
 RUN pip3 install ansible-lint
 
 COPY ansible /ansible

--- a/.github/workflows/_wait_for_workflow.yml
+++ b/.github/workflows/_wait_for_workflow.yml
@@ -1,0 +1,83 @@
+name: "Wait for Workflow"
+
+on:
+  workflow_call:
+    inputs:
+      workflow_name:
+        required: true
+        type: string
+      sha:
+        required: true
+        type: string
+    outputs:
+      artifact_exists:
+        description: "Whether a new image artifact was created"
+        value: ${{ jobs.wait.outputs.artifact_exists }}
+      run_id:
+        description: "The ID of the workflow run that created the artifact"
+        value: ${{ jobs.wait.outputs.run_id }}
+
+jobs:
+  wait:
+    runs-on: ubuntu-latest
+    outputs:
+      artifact_exists: ${{ steps.check.outputs.artifact_exists }}
+      run_id: ${{ steps.check.outputs.run_id }}
+    steps:
+      - name: Wait for workflow
+        uses: actions/github-script@v9
+        id: check
+        with:
+          script: |
+            const workflow_name = "${{ inputs.workflow_name }}";
+            const sha = "${{ inputs.sha }}";
+
+            let artifact_exists = "false";
+            let retry_count = 0;
+            const max_retries = 10; // Wait up to 5 minutes for the run to appear
+
+            while (true) {
+              const { data: runs } = await github.rest.actions.listWorkflowRuns({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: workflow_name + ".yml",
+                head_sha: sha
+              });
+
+              const run = runs.workflow_runs.find(r => r.head_sha === sha);
+
+              if (run) {
+                console.log(`Found run ${run.id} with status ${run.status}`);
+                core.setOutput("run_id", run.id.toString());
+              }
+
+              if (!run) {
+                if (retry_count < max_retries) {
+                  console.log(`No run found for this workflow and SHA. Retry ${retry_count + 1}/${max_retries}...`);
+                  retry_count++;
+                  await new Promise(resolve => setTimeout(resolve, 30000));
+                  continue;
+                } else {
+                  console.log("No run found after maximum retries. Proceeding without artifact.");
+                  break;
+                }
+              }
+
+              if (run.status === "completed") {
+                console.log(`Run completed with conclusion: ${run.conclusion}`);
+                core.setOutput("run_id", run.id.toString());
+                if (run.conclusion === "success") {
+                  if (context.ref !== 'refs/heads/main') {
+                    artifact_exists = "true";
+                  }
+                } else {
+                  core.setFailed(`Workflow ${workflow_name} failed with conclusion: ${run.conclusion}`);
+                }
+                break;
+              }
+
+              console.log(`Run is still ${run.status}. Waiting 30 seconds...`);
+              await new Promise(resolve => setTimeout(resolve, 30000));
+            }
+
+            core.setOutput("artifact_exists", artifact_exists);

--- a/.github/workflows/rebuild-container-images.yml
+++ b/.github/workflows/rebuild-container-images.yml
@@ -68,6 +68,8 @@ jobs:
           file: ./.github/workflows/Containerfile.${{ matrix.distro }}
           build-args: |
             IMAGE=${{ matrix.image }}
+          cache-from: type=gha,scope=${{ matrix.distro }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.distro }}
           push: ${{ github.ref == 'refs/heads/main' }}
           tags: ghcr.io/${{ env.REPO_NAME }}/epics-training-base-${{ matrix.distro }}:latest
           outputs: ${{ (github.ref != 'refs/heads/main') && format('type=docker,dest=/tmp/image-{0}.tar', matrix.distro) || '' }}

--- a/.github/workflows/rebuild-container-images.yml
+++ b/.github/workflows/rebuild-container-images.yml
@@ -31,7 +31,6 @@ jobs:
 
   build:
     needs: check
-    if: needs.check.outputs.branch-pr == ''
     strategy:
       fail-fast: false
       matrix:
@@ -60,6 +59,8 @@ jobs:
       - name: Set lower case repository name
         run: |
           echo "REPO_NAME=${GITHUB_REPOSITORY,,}" >> ${GITHUB_ENV}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
       - name: Build and push container image
         uses: docker/build-push-action@v7
         with:
@@ -67,5 +68,14 @@ jobs:
           file: ./.github/workflows/Containerfile.${{ matrix.distro }}
           build-args: |
             IMAGE=${{ matrix.image }}
-          push: true
+          push: ${{ github.ref == 'refs/heads/main' }}
           tags: ghcr.io/${{ env.REPO_NAME }}/epics-training-base-${{ matrix.distro }}:latest
+          outputs: ${{ (github.ref != 'refs/heads/main') && format('type=docker,dest=/tmp/image-{0}.tar', matrix.distro) || '' }}
+
+      - name: Upload image artifact
+        if: github.ref != 'refs/heads/main'
+        uses: actions/upload-artifact@v7
+        with:
+          name: epics-training-base-${{ matrix.distro }}-image
+          path: /tmp/image-${{ matrix.distro }}.tar
+          retention-days: 1

--- a/.github/workflows/test-roles-modules.yml
+++ b/.github/workflows/test-roles-modules.yml
@@ -27,6 +27,12 @@ jobs:
   check:
     uses: ./.github/workflows/_check.yml
 
+  wait:
+    uses: ./.github/workflows/_wait_for_workflow.yml
+    with:
+      workflow_name: "rebuild-container-images"
+      sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
   prep:
     runs-on: ubuntu-latest
     outputs:
@@ -36,10 +42,9 @@ jobs:
         run: echo "repo_name=${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
 
   test:
-    needs: [check, prep]
+    needs: [check, wait, prep]
     name: "${{ matrix.distro }}: ${{ matrix.conf.name }}"
     if: |
-      needs.check.outputs.branch-pr == '' &&
       (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')
     strategy:
       fail-fast: false
@@ -49,12 +54,33 @@ jobs:
           - name: "EPICS Modules"
             id: "ci-modules"
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/${{ needs.prep.outputs.repo_name }}/epics-training-base-${{ matrix.distro }}:latest
+    permissions:
+      contents: read
+      actions: read
+      packages: read
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Download image artifact
+        if: needs.wait.outputs.artifact_exists == 'true'
+        uses: actions/download-artifact@v8
+        with:
+          name: epics-training-base-${{ matrix.distro }}-image
+          path: /tmp
+          run-id: ${{ needs.wait.outputs.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Load image
+        if: needs.wait.outputs.artifact_exists == 'true'
+        run: docker load -i /tmp/image-${{ matrix.distro }}.tar
+
       - name: Build ${{ matrix.conf.name }}
         run: |
-          cd ansible
-          ansible-playbook -v playbook.yml -e "@vars/${{ matrix.conf.id }}.yml"
+          IMAGE="ghcr.io/${{ needs.prep.outputs.repo_name }}/epics-training-base-${{ matrix.distro }}:latest"
+          # If artifact exists, it was loaded into the local docker daemon with the same tag
+          # but we need to be sure about the tag. The build-push-action uses the tags provided.
+          # In rebuild-container-images.yml, we provided the ghcr.io tag even for local builds.
+
+          docker run --rm -v ${{ github.workspace }}:/workspace -w /workspace/ansible $IMAGE \
+            ansible-playbook -v playbook.yml -e "@vars/${{ matrix.conf.id }}.yml"

--- a/.github/workflows/test-roles-modules.yml
+++ b/.github/workflows/test-roles-modules.yml
@@ -82,5 +82,6 @@ jobs:
           # but we need to be sure about the tag. The build-push-action uses the tags provided.
           # In rebuild-container-images.yml, we provided the ghcr.io tag even for local builds.
 
-          docker run --rm -v ${{ github.workspace }}:/workspace -w /workspace/ansible $IMAGE \
+          docker run --rm --init --memory=6g --shm-size=2g \
+            -v ${{ github.workspace }}:/workspace -w /workspace/ansible $IMAGE \
             ansible-playbook -v playbook.yml -e "@vars/${{ matrix.conf.id }}.yml"

--- a/.github/workflows/test-roles-oac-tree.yml
+++ b/.github/workflows/test-roles-oac-tree.yml
@@ -76,5 +76,6 @@ jobs:
       - name: Build ${{ matrix.conf.name }}
         run: |
           IMAGE="ghcr.io/${{ needs.prep.outputs.repo_name }}/epics-training-base-${{ matrix.distro }}:latest"
-          docker run --rm -v ${{ github.workspace }}:/workspace -w /workspace/ansible $IMAGE \
+          docker run --rm --init --memory=6g --shm-size=2g \
+            -v ${{ github.workspace }}:/workspace -w /workspace/ansible $IMAGE \
             ansible-playbook -v playbook.yml -e "@vars/${{ matrix.conf.id }}.yml"

--- a/.github/workflows/test-roles-oac-tree.yml
+++ b/.github/workflows/test-roles-oac-tree.yml
@@ -25,6 +25,12 @@ jobs:
   check:
     uses: ./.github/workflows/_check.yml
 
+  wait:
+    uses: ./.github/workflows/_wait_for_workflow.yml
+    with:
+      workflow_name: "rebuild-container-images"
+      sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
   prep:
     runs-on: ubuntu-latest
     outputs:
@@ -34,10 +40,9 @@ jobs:
         run: echo "repo_name=${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
 
   test:
-    needs: [check, prep]
+    needs: [check, wait, prep]
     name: "${{ matrix.distro }}: ${{ matrix.conf.name }}"
     if: |
-      needs.check.outputs.branch-pr == '' &&
       (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')
     strategy:
       fail-fast: false
@@ -47,12 +52,29 @@ jobs:
           - name: "oac-tree"
             id: "ci-oac-tree"
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/${{ needs.prep.outputs.repo_name }}/epics-training-base-${{ matrix.distro }}:latest
+    permissions:
+      contents: read
+      actions: read
+      packages: read
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Download image artifact
+        if: needs.wait.outputs.artifact_exists == 'true'
+        uses: actions/download-artifact@v8
+        with:
+          name: epics-training-base-${{ matrix.distro }}-image
+          path: /tmp
+          run-id: ${{ needs.wait.outputs.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Load image
+        if: needs.wait.outputs.artifact_exists == 'true'
+        run: docker load -i /tmp/image-${{ matrix.distro }}.tar
+
       - name: Build ${{ matrix.conf.name }}
         run: |
-          cd ansible
-          ansible-playbook -v playbook.yml -e "@vars/${{ matrix.conf.id }}.yml"
+          IMAGE="ghcr.io/${{ needs.prep.outputs.repo_name }}/epics-training-base-${{ matrix.distro }}:latest"
+          docker run --rm -v ${{ github.workspace }}:/workspace -w /workspace/ansible $IMAGE \
+            ansible-playbook -v playbook.yml -e "@vars/${{ matrix.conf.id }}.yml"

--- a/.github/workflows/test-roles-phoebus-aa.yml
+++ b/.github/workflows/test-roles-phoebus-aa.yml
@@ -78,5 +78,6 @@ jobs:
       - name: Build ${{ matrix.conf.name }}
         run: |
           IMAGE="ghcr.io/${{ needs.prep.outputs.repo_name }}/epics-training-base-${{ matrix.distro }}:latest"
-          docker run --rm -v ${{ github.workspace }}:/workspace -w /workspace/ansible $IMAGE \
+          docker run --rm --init --memory=6g --shm-size=2g \
+            -v ${{ github.workspace }}:/workspace -w /workspace/ansible $IMAGE \
             ansible-playbook -v playbook.yml -e "@vars/${{ matrix.conf.id }}.yml"

--- a/.github/workflows/test-roles-phoebus-aa.yml
+++ b/.github/workflows/test-roles-phoebus-aa.yml
@@ -27,6 +27,12 @@ jobs:
   check:
     uses: ./.github/workflows/_check.yml
 
+  wait:
+    uses: ./.github/workflows/_wait_for_workflow.yml
+    with:
+      workflow_name: "rebuild-container-images"
+      sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
   prep:
     runs-on: ubuntu-latest
     outputs:
@@ -36,10 +42,9 @@ jobs:
         run: echo "repo_name=${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
 
   test:
-    needs: [check, prep]
+    needs: [check, wait, prep]
     name: "${{ matrix.distro }}: ${{ matrix.conf.name }}"
     if: |
-      needs.check.outputs.branch-pr == '' &&
       (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')
     strategy:
       fail-fast: false
@@ -49,12 +54,29 @@ jobs:
           - name: "Phoebus & Archiver"
             id: "ci-phoebus-aa"
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/${{ needs.prep.outputs.repo_name }}/epics-training-base-${{ matrix.distro }}:latest
+    permissions:
+      contents: read
+      actions: read
+      packages: read
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Download image artifact
+        if: needs.wait.outputs.artifact_exists == 'true'
+        uses: actions/download-artifact@v8
+        with:
+          name: epics-training-base-${{ matrix.distro }}-image
+          path: /tmp
+          run-id: ${{ needs.wait.outputs.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Load image
+        if: needs.wait.outputs.artifact_exists == 'true'
+        run: docker load -i /tmp/image-${{ matrix.distro }}.tar
+
       - name: Build ${{ matrix.conf.name }}
         run: |
-          cd ansible
-          ansible-playbook -v playbook.yml -e "@vars/${{ matrix.conf.id }}.yml"
+          IMAGE="ghcr.io/${{ needs.prep.outputs.repo_name }}/epics-training-base-${{ matrix.distro }}:latest"
+          docker run --rm -v ${{ github.workspace }}:/workspace -w /workspace/ansible $IMAGE \
+            ansible-playbook -v playbook.yml -e "@vars/${{ matrix.conf.id }}.yml"

--- a/ansible/roles/m-base/tasks/build_module.yml
+++ b/ansible/roles/m-base/tasks/build_module.yml
@@ -2,6 +2,7 @@
 - name: "{{ module.name }} | Install required DEB dependencies"
   ansible.builtin.apt:
     name: "{{ module.required_debs }}"
+    install_recommends: false
     state: present
     update_cache: true
   become: true
@@ -11,6 +12,7 @@
   dnf:
     name: "{{ module.required_rpms }}"
     enablerepo: "{{ module.enable_repos | default('[]') }}"
+    install_weak_deps: false
     state: present
   become: true
   when: is_redhat and module.required_rpms is defined

--- a/ansible/roles/oac-tree/tasks/main.yml
+++ b/ansible/roles/oac-tree/tasks/main.yml
@@ -114,7 +114,7 @@
   when: oactree_bundle_flag.stat.exists == false
 
 - name: "Run make (build and install everything - this may take a while)"
-  command: make -j {{ ansible_facts.processor_vcpus }} -C {{ oactree_install_path }}/src/oac-tree-bundle/build
+  command: make -j 1 -C {{ oactree_install_path }}/src/oac-tree-bundle/build
   register: build_result
   environment:
     EPICS_BASE: "{{ epics_install_path }}/base-{{ epics_base_version }}"


### PR DESCRIPTION
This is the remaining part of the workflow parallelization task.

Building container images (stage 1) and testing the roles installation (stage 2) are being properly synchronized, with stage 2 workflows waiting for the matching stage1 workflow to successfully finish.

Container images built from 'main' are stored in GHCR, while branch builds and pull requests store their images as build artefacts, providing limited scope, avoiding untested images being pushed into GHCR, removing the need for explicit cleanup and working around permission limitations.