### PR TITLE
Make GHCR uploads of stage 1 images opt-in

### DIFF
--- a/.github/workflows/_wait_for_workflow.yml
+++ b/.github/workflows/_wait_for_workflow.yml
@@ -67,9 +67,7 @@ jobs:
                 console.log(`Run completed with conclusion: ${run.conclusion}`);
                 core.setOutput("run_id", run.id.toString());
                 if (run.conclusion === "success") {
-                  if (context.ref !== 'refs/heads/main') {
-                    artifact_exists = "true";
-                  }
+                  artifact_exists = "true";
                 } else {
                   core.setFailed(`Workflow ${workflow_name} failed with conclusion: ${run.conclusion}`);
                 }

--- a/.github/workflows/rebuild-container-images.yml
+++ b/.github/workflows/rebuild-container-images.yml
@@ -70,12 +70,11 @@ jobs:
             IMAGE=${{ matrix.image }}
           cache-from: type=gha,scope=${{ matrix.distro }}
           cache-to: type=gha,mode=max,scope=${{ matrix.distro }}
-          push: ${{ github.ref == 'refs/heads/main' }}
+          push: ${{ github.ref == 'refs/heads/main' && vars.UPLOAD_GHCR != '' }}
           tags: ghcr.io/${{ env.REPO_NAME }}/epics-training-base-${{ matrix.distro }}:latest
-          outputs: ${{ (github.ref != 'refs/heads/main') && format('type=docker,dest=/tmp/image-{0}.tar', matrix.distro) || '' }}
+          outputs: type=docker,dest=/tmp/image-${{ matrix.distro }}.tar
 
       - name: Upload image artifact
-        if: github.ref != 'refs/heads/main'
         uses: actions/upload-artifact@v7
         with:
           name: epics-training-base-${{ matrix.distro }}-image


### PR DESCRIPTION
- Make `rebuild-container-images.yml` always produce and upload image artifacts
- Make GHCR uploads opt-in via `vars.UPLOAD_GHCR` setting, only on `main`
- Phase 2 jobs will always use artifacts
- closes #85

Co-authored-by: google-labs-jules[bot]