### PR TITLE
Complete and fix archiver-appliance role

### DIFF
--- a/.github/workflows/test-roles-phoebus-aa.yml
+++ b/.github/workflows/test-roles-phoebus-aa.yml
@@ -9,6 +9,7 @@ on:
       - 'ansible/requirements.yml'
       - 'ansible/roles/phoebus/**'
       - 'ansible/roles/java/**'
+      - 'ansible/roles/archiver-appliance/**'
   pull_request:
     paths:
     - '.github/workflows/test-roles-phoebus-aa.yml'
@@ -17,6 +18,7 @@ on:
     - 'ansible/requirements.yml'
     - 'ansible/roles/phoebus/**'
     - 'ansible/roles/java/**'
+    - 'ansible/roles/archiver-appliance/**'
   workflow_run:
     workflows: ["Rebuild Container Images"]
     types:

--- a/ansible/roles/archiver-appliance/defaults/main.yml
+++ b/ansible/roles/archiver-appliance/defaults/main.yml
@@ -18,6 +18,7 @@ archiver_appliance_java_max_heapsize: "512M"
 
 # --- The user whose Firefox profile we are modifying ---
 firefox_user: "{{ dev_user }}"
+firefox_profile_name: "default"
 
 # --- Bookmark Details ---
 bookmark_title: "Archiver"

--- a/ansible/roles/archiver-appliance/tasks/add_firefox_bookmark.yml
+++ b/ansible/roles/archiver-appliance/tasks/add_firefox_bookmark.yml
@@ -13,12 +13,21 @@
     name: sqlite
     state: present
 
+- name: Ensure Firefox profile exists
+  become: true
+  become_user: "{{ firefox_user }}"
+  ansible.builtin.shell:
+    cmd: "firefox -headless -CreateProfile {{ firefox_profile_name }} || true"
+  environment:
+    DISPLAY: ":0"
+  changed_when: false
+
 - name: Find the default Firefox profile directory
   ansible.builtin.find:
     paths:
       - "/home/{{ firefox_user }}/.mozilla/firefox/"
       - "/home/{{ firefox_user }}/snap/firefox/common/.mozilla/firefox/"
-    patterns: "*.default,*.default-release" # Common patterns for default profiles
+    patterns: "*.default,*.default-release,*.default-default" # Common patterns for default profiles
     file_type: directory
   register: ff_profile_find
 

--- a/ansible/roles/archiver-appliance/tasks/install_appliance.yml
+++ b/ansible/roles/archiver-appliance/tasks/install_appliance.yml
@@ -1,4 +1,4 @@
---- 
+---
 - name: Create temporary location for WAR unpacking
   become: true
   ansible.builtin.file:

--- a/ansible/roles/archiver-appliance/tasks/install_mariadb.yml
+++ b/ansible/roles/archiver-appliance/tasks/install_mariadb.yml
@@ -13,7 +13,9 @@
 - name: Install required RPM dependencies
   become: true
   ansible.builtin.dnf:
-    name: mariadb-server
+    name:
+      - mariadb-server
+      - python3-PyMySQL
     update_cache: true
     state: present
   when: is_redhat
@@ -21,21 +23,25 @@
 - name: Manage MariaDB service; create AA user and database
   become: true
   when: not in_container
-  block: 
+  block:
     - name: Manage MariaDB service
       ansible.builtin.systemd_service:
         name: mariadb
         state: started
         enabled: true
 
+    - name: Set MariaDB socket path
+      ansible.builtin.set_fact:
+        mariadb_socket: "{{ '/var/run/mysqld/mysqld.sock' if is_debian else '/var/lib/mysql/mysql.sock' }}"
+
     - name: MariaDB - create Archiver-Appliance database
       community.mysql.mysql_db:
-        login_unix_socket: /var/run/mysqld/mysqld.sock
+        login_unix_socket: "{{ mariadb_socket }}"
         name: archappl
 
     - name: MariaDB - create Archiver-Appliance user
       community.mysql.mysql_user:
-        login_unix_socket: /var/run/mysqld/mysqld.sock
+        login_unix_socket: "{{ mariadb_socket }}"
         name: archappl
         password: archappl
         priv: 'archappl.*:ALL'

--- a/ansible/roles/archiver-appliance/tasks/main.yml
+++ b/ansible/roles/archiver-appliance/tasks/main.yml
@@ -72,6 +72,10 @@
   notify:
     - Restart archiver-appliance
 
+- name: "Run the Archiver-Appliance's MariaDB install script"
+  ansible.builtin.shell:
+    cmd: "mariadb -u archappl —password=archappl archappl < {{ tomcat_home }}/webapps/mgmt/install/archappl_mysql.sql || true"
+
 - name: Create Archiver Appliance systemd service
   become: true
   ansible.builtin.template:


### PR DESCRIPTION
Fixes and completes the archiver-appliance role.

- make sure Firefox default profile exists before adding bookmark
- make archiver-appliance role work on all Training-VM flavors
- fix: run the AA's MariaDB install script
- add the appropriate triggers to the phoebus-aa job on GitHub Actions.

Thanks a lot to @waynelewis for his contributions.
(fixes #70)